### PR TITLE
feat(editor): add operator/group cards

### DIFF
--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -10,27 +10,31 @@ import {
   Controller,
   ControllerProps,
   FieldError,
+  FieldValues,
   Path,
 } from 'react-hook-form'
 import { WithChildren } from 'types'
 
-export interface FormFieldRenderProps<T> {
+export interface FormFieldRenderProps<
+  T extends FieldValues,
+  P extends Path<T>,
+> {
   name: Path<T>
   control: Control<T>
-  props?: Omit<ControllerProps<T>, 'name' | 'render'>
+  props?: Omit<ControllerProps<T, P>, 'name' | 'render'>
 }
 
-export interface FormFieldProps<T> {
+export interface FormFieldProps<T extends FieldValues, P extends Path<T>> {
   FormGroupProps?: Omit<FormGroupProps, 'label' | 'labelFor'>
   control: Control<T>
   error?: FieldError
   label: ReactNode
-  field: Path<T>
-  ControllerProps?: Omit<ControllerProps<T>, 'name'>
-  render?: (props: FormFieldRenderProps<T>) => ReactNode
+  field: P
+  ControllerProps?: Omit<ControllerProps<T, P>, 'name'>
+  render?: (props: FormFieldRenderProps<T, P>) => ReactNode
 }
 
-export const FormField = <T,>({
+export const FormField = <T extends FieldValues, P extends Path<T>>({
   ControllerProps,
   FormGroupProps,
   control,
@@ -38,7 +42,7 @@ export const FormField = <T,>({
   label,
   field,
   render,
-}: FormFieldProps<T>) => {
+}: FormFieldProps<T, P>) => {
   return (
     <FormGroup
       label={

--- a/src/components/dnd.tsx
+++ b/src/components/dnd.tsx
@@ -1,0 +1,64 @@
+import { UniqueIdentifier, useDroppable } from '@dnd-kit/core'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { FC, ReactNode } from 'react'
+
+export type SortableItemProps = ReturnType<typeof useSortable>
+
+export interface SortableProps {
+  id: UniqueIdentifier
+  data?: Record<string, any>
+  children: ReactNode | ((childProps: SortableItemProps) => ReactNode)
+}
+
+export const Sortable: FC<SortableProps> = ({ id, data, children }) => {
+  const sortable = useSortable({
+    id,
+    data,
+    transition: {
+      duration: 250, // milliseconds
+      easing: 'cubic-bezier(0.25, 1, 0.5, 1)',
+    },
+  })
+
+  const { attributes, listeners, setNodeRef, transform, transition } = sortable
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  if (typeof children === 'function') {
+    return (
+      <div ref={setNodeRef} style={style}>
+        {children(sortable)}
+      </div>
+    )
+  }
+
+  return (
+    <div ref={setNodeRef} {...listeners} {...attributes} style={style}>
+      {children}
+    </div>
+  )
+}
+
+export type DroppableItemProps = ReturnType<typeof useDroppable>
+
+export interface DroppableProps {
+  id: UniqueIdentifier
+  data?: Record<string, any>
+  children: ReactNode | ((childProps: DroppableItemProps) => ReactNode)
+}
+
+export const Droppable: FC<DroppableProps> = ({ id, data, children }) => {
+  const droppable = useDroppable({ id, data })
+
+  const { setNodeRef } = droppable
+
+  if (typeof children === 'function') {
+    return <div ref={setNodeRef}>{children(droppable)}</div>
+  }
+
+  return <div ref={setNodeRef}>{children}</div>
+}

--- a/src/components/editor/DetailedSelect.tsx
+++ b/src/components/editor/DetailedSelect.tsx
@@ -68,3 +68,9 @@ export const DetailedSelect: FCC<
     </DetailedSelect2>
   )
 }
+
+export function isChoice(
+  item: DetailedSelectItem,
+): item is DetailedSelectChoice {
+  return item.type === 'choice'
+}

--- a/src/components/editor/OperationEditor.tsx
+++ b/src/components/editor/OperationEditor.tsx
@@ -49,7 +49,7 @@ export const StageNameInput: FC<{
         keys: ['name', 'catOne', 'catTwo', 'catThree'],
         threshold: 0.3,
       }),
-    [],
+    [levels],
   )
 
   return (

--- a/src/components/editor/OperationEditor.tsx
+++ b/src/components/editor/OperationEditor.tsx
@@ -153,7 +153,7 @@ export const OperationEditor: FC<{
         <Button intent="primary" className="ml-4" icon="upload" text="发布" />
       </div>
 
-      {import.meta.env.PROD && (
+      {import.meta.env.PROD && !location.href.includes('azurestaticapps') && (
         <Overlay
           isOpen
           hasBackdrop={false}

--- a/src/components/editor/operator/EditorGroupItem.tsx
+++ b/src/components/editor/operator/EditorGroupItem.tsx
@@ -1,0 +1,13 @@
+import { MenuItem } from '@blueprintjs/core'
+
+interface EditorGroupItemProps {
+  group: CopilotDocV1.Group
+}
+
+export const EditorGroupItem = ({ group }: EditorGroupItemProps) => {
+  return (
+    <div className="">
+      <MenuItem key={group.name} text={group.name} />
+    </div>
+  )
+}

--- a/src/components/editor/operator/EditorGroupItem.tsx
+++ b/src/components/editor/operator/EditorGroupItem.tsx
@@ -1,13 +1,58 @@
-import { MenuItem } from '@blueprintjs/core'
+import { Card, Elevation, Icon } from '@blueprintjs/core'
+import { UniqueIdentifier } from '@dnd-kit/core'
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import { clsx } from 'clsx'
+import { Sortable, SortableItemProps } from '../../dnd'
+import { EditorOperatorItem } from './EditorOperatorItem'
 
-interface EditorGroupItemProps {
-  group: CopilotDocV1.Group
+export type GroupWithIdentifiedOperators = Omit<CopilotDocV1.Group, 'opers'> & {
+  opers: (CopilotDocV1.Operator & { id: UniqueIdentifier })[]
 }
 
-export const EditorGroupItem = ({ group }: EditorGroupItemProps) => {
+interface EditorGroupItemProps extends Partial<SortableItemProps> {
+  group: CopilotDocV1.Group
+  getOperatorId: (operator: CopilotDocV1.Operator) => UniqueIdentifier
+}
+
+export const EditorGroupItem = ({
+  group,
+  getOperatorId,
+  isDragging,
+  attributes,
+  listeners,
+}: EditorGroupItemProps) => {
   return (
-    <div className="">
-      <MenuItem key={group.name} text={group.name} />
-    </div>
+    <Card elevation={Elevation.TWO} className={clsx(isDragging && 'invisible')}>
+      <SortableContext
+        items={group.opers?.map(getOperatorId) || []}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="flex">
+          <Icon
+            className="cursor-grab active:cursor-grabbing p-1 -my-1 -ml-2 rounded-[1px]"
+            icon="drag-handle-vertical"
+            {...attributes}
+            {...listeners}
+          />
+
+          <h3 className="font-bold leading-none mb-4">{group.name}</h3>
+        </div>
+
+        <ul>
+          {group.opers?.map((operator) => (
+            <li className="mb-2" key={getOperatorId(operator)}>
+              <Sortable
+                id={getOperatorId(operator)}
+                data={{ type: 'operator' }}
+              >
+                {(attrs) => (
+                  <EditorOperatorItem operator={operator} {...attrs} />
+                )}
+              </Sortable>
+            </li>
+          ))}
+        </ul>
+      </SortableContext>
+    </Card>
   )
 }

--- a/src/components/editor/operator/EditorOperatorItem.tsx
+++ b/src/components/editor/operator/EditorOperatorItem.tsx
@@ -1,0 +1,27 @@
+import { Card, Elevation } from '@blueprintjs/core'
+import { OPERATORS } from '../../../models/generated/operators'
+import { findOperatorSkillUsage } from '../../../models/operator'
+import { OperatorAvatar } from './EditorOperator'
+
+interface EditorOperatorItemProps {
+  operator: CopilotDocV1.Operator
+}
+
+export const EditorOperatorItem = ({ operator }: EditorOperatorItemProps) => {
+  const id = OPERATORS.find(({ name }) => name === operator.name)?.id
+  const skillUsage = findOperatorSkillUsage(operator.skillUsage)?.title
+
+  const skill = `${
+    [null, '一', '二', '三'][operator.skill ?? 1] ?? '未知'
+  }技能：${skillUsage}`
+
+  return (
+    <Card elevation={Elevation.TWO} className="flex">
+      <OperatorAvatar id={id} size="large" />
+      <div className="ml-4">
+        <h3 className="font-bold leading-none mb-1">{operator.name}</h3>
+        <div className="text-gray-400">{skill}</div>
+      </div>
+    </Card>
+  )
+}

--- a/src/components/editor/operator/EditorOperatorItem.tsx
+++ b/src/components/editor/operator/EditorOperatorItem.tsx
@@ -1,13 +1,20 @@
-import { Card, Elevation } from '@blueprintjs/core'
+import { Card, Elevation, Icon } from '@blueprintjs/core'
+import clsx from 'clsx'
 import { OPERATORS } from '../../../models/generated/operators'
 import { findOperatorSkillUsage } from '../../../models/operator'
+import { SortableItemProps } from '../../dnd'
 import { OperatorAvatar } from './EditorOperator'
 
-interface EditorOperatorItemProps {
+interface EditorOperatorItemProps extends Partial<SortableItemProps> {
   operator: CopilotDocV1.Operator
 }
 
-export const EditorOperatorItem = ({ operator }: EditorOperatorItemProps) => {
+export const EditorOperatorItem = ({
+  operator,
+  isDragging,
+  attributes,
+  listeners,
+}: EditorOperatorItemProps) => {
   const id = OPERATORS.find(({ name }) => name === operator.name)?.id
   const skillUsage = findOperatorSkillUsage(operator.skillUsage)?.title
 
@@ -16,7 +23,16 @@ export const EditorOperatorItem = ({ operator }: EditorOperatorItemProps) => {
   }技能：${skillUsage}`
 
   return (
-    <Card elevation={Elevation.TWO} className="flex">
+    <Card
+      elevation={Elevation.TWO}
+      className={clsx('flex', isDragging && 'opacity-30')}
+    >
+      <Icon
+        className="cursor-grab active:cursor-grabbing p-1 -my-1 -ml-2 mr-3 rounded-[1px]"
+        icon="drag-handle-vertical"
+        {...attributes}
+        {...listeners}
+      />
       <OperatorAvatar id={id} size="large" />
       <div className="ml-4">
         <h3 className="font-bold leading-none mb-1">{operator.name}</h3>

--- a/src/components/editor/operator/EditorOperatorSkillUsage.tsx
+++ b/src/components/editor/operator/EditorOperatorSkillUsage.tsx
@@ -2,11 +2,10 @@ import { Button } from '@blueprintjs/core'
 import {
   DetailedSelect,
   DetailedSelectChoice,
-  DetailedSelectItem,
 } from 'components/editor/DetailedSelect'
 import { EditorFieldProps } from 'components/editor/EditorFieldProps'
-import { useMemo } from 'react'
 import { useController } from 'react-hook-form'
+import { operatorSkillUsages } from '../../../models/operator'
 
 export const EditorOperatorSkillUsage = <T,>({
   name,
@@ -19,49 +18,13 @@ export const EditorOperatorSkillUsage = <T,>({
     control,
   })
 
-  const menuItems = useMemo<DetailedSelectItem[]>(
-    () => [
-      {
-        type: 'choice',
-        icon: 'disable',
-        title: '不自动使用',
-        value: 0,
-        description:
-          '不由 MAA Copilot 自动开启技能、或干员技能并不需要操作开启（自动触发）。若需要手动开启技能，请添加「使用技能」动作',
-      },
-      {
-        type: 'choice',
-        icon: 'automatic-updates',
-        title: '好了就用，有多少次用多少次',
-        value: 1,
-        description: '例如：棘刺 3 技能、桃金娘 1 技能等',
-      },
-      {
-        type: 'choice',
-        icon: 'circle',
-        title: '好了就用，仅使用一次',
-        value: 2,
-        description: '例如：山 2 技能',
-      },
-      {
-        type: 'choice',
-        icon: 'predictive-analysis',
-        title: '自动判断使用时机',
-        value: 3,
-        description: '(锐意开发中) 画饼.jpg',
-        disabled: true,
-      },
-    ],
-    [],
-  )
-
-  const selectedAction = menuItems.find(
+  const selectedAction = operatorSkillUsages.find(
     (action) => action.type === 'choice' && action.value === (value ?? 0),
   ) as DetailedSelectChoice | undefined
 
   return (
     <DetailedSelect
-      items={menuItems}
+      items={operatorSkillUsages}
       onItemSelect={(item) => {
         onChange(item.value)
       }}

--- a/src/components/editor/operator/EditorPerformer.tsx
+++ b/src/components/editor/operator/EditorPerformer.tsx
@@ -1,20 +1,23 @@
-import { Button, Card, MenuItem } from '@blueprintjs/core'
+import { Button, Card, MenuItem, NonIdealState } from '@blueprintjs/core'
 import { Select2 } from '@blueprintjs/select'
 import { FC, useMemo, useState } from 'react'
-import { Control } from 'react-hook-form'
+import { Control, useFieldArray } from 'react-hook-form'
+import { AppToaster } from '../../Toaster'
+import { EditorGroupItem } from './EditorGroupItem'
+import { EditorOperatorItem } from './EditorOperatorItem'
 import { EditorPerformerGroup } from './EditorPerformerGroup'
 import { EditorPerformerOperator } from './EditorPerformerOperator'
 
+type PerformerType = 'operator' | 'group'
+
 export interface EditorPerformerAddProps {
-  append: (
-    type: 'operator' | 'group',
-    performer: CopilotDocV1.Operator | CopilotDocV1.Group,
-  ) => void
+  appendOperator: (operator: CopilotDocV1.Operator) => void
+  appendGroup: (group: CopilotDocV1.Group) => void
 }
 
 interface PerformerSelectItem {
   label: string
-  value: 'operator' | 'group'
+  value: PerformerType
 }
 
 const performerSelectItems: PerformerSelectItem[] = [
@@ -22,8 +25,11 @@ const performerSelectItems: PerformerSelectItem[] = [
   { label: '干员组', value: 'group' },
 ]
 
-export const EditorPerformerAdd = ({ append }) => {
-  const [mode, setMode] = useState<'operator' | 'group'>('operator')
+export const EditorPerformerAdd: FC<EditorPerformerAddProps> = ({
+  appendOperator,
+  appendGroup,
+}) => {
+  const [mode, setMode] = useState<PerformerType>('operator')
 
   const activeItem =
     performerSelectItems.find((item) => item.value === mode) ||
@@ -63,20 +69,13 @@ export const EditorPerformerAdd = ({ append }) => {
   const child = useMemo(() => {
     return mode === 'operator' ? (
       <EditorPerformerOperator
-        submit={(values) => {
-          append(values)
-        }}
+        submit={appendOperator}
         categorySelector={selector}
       />
     ) : (
-      <EditorPerformerGroup
-        submit={(values) => {
-          append(values)
-        }}
-        categorySelector={selector}
-      />
+      <EditorPerformerGroup submit={appendGroup} categorySelector={selector} />
     )
-  }, [mode])
+  }, [mode, appendOperator, appendGroup])
 
   return <Card className="mb-8 pt-4">{child}</Card>
 }
@@ -89,10 +88,74 @@ export interface EditorPerformerChildProps {
 export const EditorPerformer: FC<{
   control: Control<CopilotDocV1.Operation>
 }> = ({ control }) => {
+  const {
+    fields: operators,
+    append: _appendOperator,
+    move,
+  } = useFieldArray({
+    name: 'opers',
+    control,
+  })
+  const { fields: groups, append: _appendGroup } = useFieldArray({
+    name: 'groups',
+    control,
+  })
+
+  const appendOperator = (operator: CopilotDocV1.Operator) => {
+    if (operators.find(({ name }) => name === operator.name)) {
+      AppToaster.show({
+        intent: 'warning',
+        message: '该干员已存在',
+      })
+      return
+    }
+
+    _appendOperator(operator)
+  }
+
+  const appendGroup = (group: CopilotDocV1.Group) => {
+    if (groups.find(({ name }) => name === group.name)) {
+      AppToaster.show({
+        intent: 'warning',
+        message: '该干员组已存在',
+      })
+      return
+    }
+
+    _appendGroup(group)
+  }
+
   return (
     <>
-      {/* {categorySelector} */}
-      <EditorPerformerAdd />
+      <EditorPerformerAdd
+        appendOperator={appendOperator}
+        appendGroup={appendGroup}
+      />
+
+      <div className="p-2 -mx-2 relative">
+        {groups.length !== 0 && (
+          <ul>
+            {groups.map((group) => (
+              <li key={group.name}>
+                <EditorGroupItem group={group} />
+              </li>
+            ))}
+          </ul>
+        )}
+        {operators.length !== 0 && (
+          <ul>
+            {operators.map((operator) => (
+              <li className="mb-2" key={operator.name}>
+                <EditorOperatorItem operator={operator} />
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {operators.length === 0 && groups.length === 0 && (
+          <NonIdealState title="暂无干员" icon="inbox" />
+        )}
+      </div>
     </>
   )
 }

--- a/src/components/editor/operator/EditorPerformer.tsx
+++ b/src/components/editor/operator/EditorPerformer.tsx
@@ -1,160 +1,273 @@
-import { Button, Card, MenuItem, NonIdealState } from '@blueprintjs/core'
-import { Select2 } from '@blueprintjs/select'
-import { FC, useMemo, useState } from 'react'
-import { Control, useFieldArray } from 'react-hook-form'
-import { AppToaster } from '../../Toaster'
+import { NonIdealState } from '@blueprintjs/core'
+import {
+  Active,
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  Over,
+  PointerSensor,
+  UniqueIdentifier,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  arraySwap,
+  SortableContext,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { FC, useState } from 'react'
+import { Control, useFieldArray, UseFieldArrayMove } from 'react-hook-form'
+import { SetRequired } from 'type-fest'
+import { FieldError } from '../../../utils/fieldError'
+import { Droppable, Sortable } from '../../dnd'
 import { EditorGroupItem } from './EditorGroupItem'
 import { EditorOperatorItem } from './EditorOperatorItem'
-import { EditorPerformerGroup } from './EditorPerformerGroup'
-import { EditorPerformerOperator } from './EditorPerformerOperator'
+import {
+  EditorPerformerAdd,
+  EditorPerformerAddProps,
+} from './EditorPerformerAdd'
 
-type PerformerType = 'operator' | 'group'
+const nonGroupedContainerId = 'nonGrouped'
 
-export interface EditorPerformerAddProps {
-  appendOperator: (operator: CopilotDocV1.Operator) => void
-  appendGroup: (group: CopilotDocV1.Group) => void
-}
+// use .name as ID instead of .id because .id may not exist in operators inside group.opers
+const getOperatorId = (operator: CopilotDocV1.Operator) => operator.name
 
-interface PerformerSelectItem {
-  label: string
-  value: PerformerType
-}
-
-const performerSelectItems: PerformerSelectItem[] = [
-  { label: '干员', value: 'operator' },
-  { label: '干员组', value: 'group' },
-]
-
-export const EditorPerformerAdd: FC<EditorPerformerAddProps> = ({
-  appendOperator,
-  appendGroup,
-}) => {
-  const [mode, setMode] = useState<PerformerType>('operator')
-
-  const activeItem =
-    performerSelectItems.find((item) => item.value === mode) ||
-    performerSelectItems[0]
-
-  const selector = (
-    <>
-      添加
-      <Select2<PerformerSelectItem>
-        filterable={false}
-        items={performerSelectItems}
-        className="ml-1"
-        onItemSelect={(e) => {
-          console.log('selected', e.value)
-          setMode(e.value)
-        }}
-        itemRenderer={(action, { handleClick, handleFocus, modifiers }) => (
-          <MenuItem
-            key={action.value}
-            selected={modifiers.active}
-            onClick={handleClick}
-            onFocus={handleFocus}
-            text={action.label}
-          />
-        )}
-        activeItem={activeItem}
-      >
-        <Button
-          large
-          text={activeItem.label}
-          rightIcon="double-caret-vertical"
-        />
-      </Select2>
-    </>
-  )
-
-  const child = useMemo(() => {
-    return mode === 'operator' ? (
-      <EditorPerformerOperator
-        submit={appendOperator}
-        categorySelector={selector}
-      />
-    ) : (
-      <EditorPerformerGroup submit={appendGroup} categorySelector={selector} />
-    )
-  }, [mode, appendOperator, appendGroup])
-
-  return <Card className="mb-8 pt-4">{child}</Card>
-}
-
-export interface EditorPerformerChildProps {
-  submit: (action: CopilotDocV1.Operator) => void
-  categorySelector: JSX.Element
-}
+// add a prefix to prevent ID collision, not really necessary because we already got data.type,
+// but just in case
+const getGroupId = (group: CopilotDocV1.Group) => 'group:' + group.name
 
 export const EditorPerformer: FC<{
   control: Control<CopilotDocV1.Operation>
 }> = ({ control }) => {
+  const sensors = useSensors(useSensor(PointerSensor))
+
   const {
     fields: operators,
-    append: _appendOperator,
-    move,
+    append: appendOperator,
+    move: moveOperator,
+    remove: removeOperator,
   } = useFieldArray({
     name: 'opers',
     control,
   })
-  const { fields: groups, append: _appendGroup } = useFieldArray({
+
+  const {
+    fields: groups,
+    append: appendGroup,
+    move: moveGroup,
+    update: updateGroup,
+  } = useFieldArray({
     name: 'groups',
     control,
   })
 
-  const appendOperator = (operator: CopilotDocV1.Operator) => {
-    if (operators.find(({ name }) => name === operator.name)) {
-      AppToaster.show({
-        intent: 'warning',
-        message: '该干员已存在',
-      })
-      return
-    }
+  const [activeOperator, setActiveOperator] = useState<CopilotDocV1.Operator>()
+  const [activeGroup, setActiveGroup] = useState<CopilotDocV1.Group>()
 
-    _appendOperator(operator)
+  const findOperatorById = (id: UniqueIdentifier) =>
+    // find operator from operators
+    operators.find((op) => getOperatorId(op) === id) ||
+    // find operator from inside groups
+    (groups
+      .map(({ opers }) => opers)
+      .flat()
+      .find((op) => op && getOperatorId(op) === id) as
+      | typeof operators[number]
+      | undefined)
+
+  const findGroupById = (id: UniqueIdentifier) =>
+    groups.find((group) => getGroupId(group) === id)
+
+  const findGroupByOperator = (operator?: CopilotDocV1.Operator) =>
+    operator &&
+    (groups.find((group) => group.opers?.includes(operator)) as
+      | SetRequired<typeof groups[number], 'opers'>
+      | undefined)
+
+  const getType = (item: Active | Over) =>
+    item.data.current?.type as 'operator' | 'group'
+
+  const handleDragStart = ({ active }: DragStartEvent) => {
+    if (getType(active) === 'operator') {
+      setActiveOperator(findOperatorById(active.id))
+    } else {
+      setActiveGroup(findGroupById(active.id))
+    }
   }
 
-  const appendGroup = (group: CopilotDocV1.Group) => {
-    if (groups.find(({ name }) => name === group.name)) {
-      AppToaster.show({
-        intent: 'warning',
-        message: '该干员组已存在',
-      })
+  const handleDragOver = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) {
       return
     }
 
-    _appendGroup(group)
+    // move operator between groups, or make it non-grouped
+    if (getType(active) === 'operator') {
+      const operator = findOperatorById(active.id)
+
+      if (operator) {
+        const oldGroup = findGroupByOperator(operator)
+        const newGroup =
+          getType(over) === 'group'
+            ? findGroupById(over.id)
+            : findGroupByOperator(findOperatorById(over.id))
+
+        if (oldGroup !== newGroup) {
+          if (oldGroup) {
+            updateGroup(groups.indexOf(oldGroup), {
+              ...oldGroup,
+              opers: oldGroup.opers?.filter(
+                ({ name }) => name !== operator.name,
+              ),
+            })
+          } else {
+            removeOperator(operators.indexOf(operator))
+          }
+
+          if (newGroup) {
+            updateGroup(groups.indexOf(newGroup), {
+              ...newGroup,
+              opers: [operator, ...(newGroup.opers || [])],
+            })
+          } else {
+            appendOperator(operator)
+          }
+        }
+      }
+    }
+
+    // move item
+    if (getType(active) === getType(over)) {
+      const moveItem = <T extends CopilotDocV1.Operator | CopilotDocV1.Group>(
+        items: T[],
+        getId: (item: T) => UniqueIdentifier,
+        move: UseFieldArrayMove,
+      ) => {
+        const oldIndex = items.findIndex((item) => getId(item) === active.id)
+        const newIndex = items.findIndex((item) => getId(item) === over.id)
+        if (oldIndex !== -1 && newIndex !== -1) move(oldIndex, newIndex)
+      }
+
+      if (getType(active) === 'operator') {
+        const operator = findOperatorById(active.id)
+
+        if (operator) {
+          const group = findGroupByOperator(operator)
+
+          if (group) {
+            moveItem(group.opers, getOperatorId, (oldIndex, newIndex) => {
+              updateGroup(groups.indexOf(group), {
+                ...group,
+                opers: arraySwap(group.opers, oldIndex, newIndex),
+              })
+            })
+          } else {
+            moveItem(operators, getOperatorId, moveOperator)
+          }
+        }
+      } else if (getType(active) === 'group') {
+        moveItem(groups, getGroupId, moveGroup)
+      }
+    }
+  }
+
+  const handleDragEnd = () => {
+    setActiveOperator(undefined)
+    setActiveGroup(undefined)
+  }
+
+  const submitOperator: EditorPerformerAddProps['submitOperator'] = (
+    operator,
+  ) => {
+    if (findOperatorById(getOperatorId(operator))) {
+      throw new FieldError('name', '该干员已存在')
+    }
+
+    appendOperator(operator)
+  }
+
+  const submitGroup: EditorPerformerAddProps['submitGroup'] = (group) => {
+    if (findGroupById(getGroupId(group))) {
+      throw new FieldError('name', '该干员组已存在')
+    }
+
+    appendGroup(group)
   }
 
   return (
     <>
       <EditorPerformerAdd
-        appendOperator={appendOperator}
-        appendGroup={appendGroup}
+        submitOperator={submitOperator}
+        submitGroup={submitGroup}
       />
-
       <div className="p-2 -mx-2 relative">
-        {groups.length !== 0 && (
-          <ul>
-            {groups.map((group) => (
-              <li key={group.name}>
-                <EditorGroupItem group={group} />
-              </li>
-            ))}
-          </ul>
-        )}
-        {operators.length !== 0 && (
-          <ul>
-            {operators.map((operator) => (
-              <li className="mb-2" key={operator.name}>
-                <EditorOperatorItem operator={operator} />
-              </li>
-            ))}
-          </ul>
-        )}
+        <DndContext
+          sensors={sensors}
+          onDragStart={handleDragStart}
+          onDragOver={handleDragOver}
+          onDragEnd={handleDragEnd}
+        >
+          <Droppable id={nonGroupedContainerId}>
+            <div className="font-bold">干员</div>
 
-        {operators.length === 0 && groups.length === 0 && (
-          <NonIdealState title="暂无干员" icon="inbox" />
-        )}
+            {operators.length === 0 && <NonIdealState title="暂无干员" />}
+
+            <SortableContext
+              items={operators.map(getOperatorId)}
+              strategy={verticalListSortingStrategy}
+            >
+              <ul>
+                {operators.map((operator) => (
+                  <li className="mt-2" key={getOperatorId(operator)}>
+                    <Sortable
+                      id={getOperatorId(operator)}
+                      data={{ type: 'operator' }}
+                    >
+                      {(attrs) => (
+                        <EditorOperatorItem operator={operator} {...attrs} />
+                      )}
+                    </Sortable>
+                  </li>
+                ))}
+              </ul>
+            </SortableContext>
+          </Droppable>
+
+          <div className="font-bold mt-8">干员组</div>
+
+          {groups.length === 0 && <NonIdealState title="暂无干员组" />}
+
+          <SortableContext
+            items={groups.map(getGroupId)}
+            strategy={verticalListSortingStrategy}
+          >
+            <ul>
+              {groups.map((group) => (
+                <li className="mt-2" key={getGroupId(group)}>
+                  <Sortable id={getGroupId(group)} data={{ type: 'group' }}>
+                    {(attrs) => (
+                      <EditorGroupItem
+                        group={group}
+                        getOperatorId={getOperatorId}
+                        {...attrs}
+                      />
+                    )}
+                  </Sortable>
+                </li>
+              ))}
+            </ul>
+          </SortableContext>
+
+          <DragOverlay>
+            {activeOperator && <EditorOperatorItem operator={activeOperator} />}
+            {activeGroup && (
+              <EditorGroupItem
+                group={activeGroup}
+                getOperatorId={getOperatorId}
+              />
+            )}
+          </DragOverlay>
+        </DndContext>
       </div>
     </>
   )

--- a/src/components/editor/operator/EditorPerformerAdd.tsx
+++ b/src/components/editor/operator/EditorPerformerAdd.tsx
@@ -1,0 +1,83 @@
+import { Button, Card, MenuItem } from '@blueprintjs/core'
+import { Select2 } from '@blueprintjs/select'
+import { FC, useMemo, useState } from 'react'
+import {
+  EditorPerformerGroup,
+  EditorPerformerGroupProps,
+} from './EditorPerformerGroup'
+import {
+  EditorPerformerOperator,
+  EditorPerformerOperatorProps,
+} from './EditorPerformerOperator'
+
+export interface EditorPerformerAddProps {
+  submitOperator: EditorPerformerOperatorProps['submit']
+  submitGroup: EditorPerformerGroupProps['submit']
+}
+
+type PerformerType = 'operator' | 'group'
+
+interface PerformerSelectItem {
+  label: string
+  value: PerformerType
+}
+
+const performerSelectItems: PerformerSelectItem[] = [
+  { label: '干员', value: 'operator' },
+  { label: '干员组', value: 'group' },
+]
+
+export const EditorPerformerAdd: FC<EditorPerformerAddProps> = ({
+  submitOperator,
+  submitGroup,
+}) => {
+  const [mode, setMode] = useState<PerformerType>('operator')
+
+  const activeItem =
+    performerSelectItems.find((item) => item.value === mode) ||
+    performerSelectItems[0]
+
+  const selector = (
+    <>
+      添加
+      <Select2<PerformerSelectItem>
+        filterable={false}
+        items={performerSelectItems}
+        className="ml-1"
+        onItemSelect={(e) => {
+          console.log('selected', e.value)
+          setMode(e.value)
+        }}
+        itemRenderer={(action, { handleClick, handleFocus, modifiers }) => (
+          <MenuItem
+            key={action.value}
+            selected={modifiers.active}
+            onClick={handleClick}
+            onFocus={handleFocus}
+            text={action.label}
+          />
+        )}
+        activeItem={activeItem}
+      >
+        <Button
+          large
+          text={activeItem.label}
+          rightIcon="double-caret-vertical"
+        />
+      </Select2>
+    </>
+  )
+
+  const child = useMemo(() => {
+    return mode === 'operator' ? (
+      <EditorPerformerOperator
+        submit={submitOperator}
+        categorySelector={selector}
+      />
+    ) : (
+      <EditorPerformerGroup submit={submitGroup} categorySelector={selector} />
+    )
+  }, [mode, submitOperator, submitGroup])
+
+  return <Card className="mb-8 pt-4">{child}</Card>
+}

--- a/src/components/editor/operator/EditorPerformerGroup.tsx
+++ b/src/components/editor/operator/EditorPerformerGroup.tsx
@@ -1,25 +1,42 @@
-import { Button } from '@blueprintjs/core'
+import { Button, InputGroup } from '@blueprintjs/core'
 import { CardTitle } from 'components/CardTitle'
 import { EditorResetButton } from 'components/editor/EditorResetButton'
-import { FormField2 } from 'components/FormField'
-import { SubmitHandler, useForm } from 'react-hook-form'
-import { EditorOperatorSelect } from './EditorOperatorSelect'
-import { EditorPerformerChildProps } from './EditorPerformer'
+import { FormField } from 'components/FormField'
+import { SubmitHandler, useForm, UseFormSetError } from 'react-hook-form'
+import { handleFieldError } from '../../../utils/fieldError'
+
+export interface EditorPerformerGroupProps {
+  submit: (group: CopilotDocV1.Group) => void
+  categorySelector: JSX.Element
+}
 
 export const EditorPerformerGroup = ({
   submit,
   categorySelector,
-}: EditorPerformerChildProps) => {
+}: EditorPerformerGroupProps) => {
   const {
     control,
     reset,
     handleSubmit,
+    setError,
     formState: { errors, isValid, isDirty },
-  } = useForm<CopilotDocV1.Group>()
+  } = useForm<CopilotDocV1.Group>({
+    defaultValues: {
+      name: '',
+    },
+  })
 
   const onSubmit: SubmitHandler<CopilotDocV1.Group> = (values) => {
-    submit(values)
-    reset()
+    try {
+      submit({
+        ...values,
+        name: values.name.trim(),
+      })
+      reset()
+    } catch (e) {
+      handleFieldError(setError, e)
+      console.warn(e)
+    }
   }
 
   return (
@@ -31,18 +48,25 @@ export const EditorPerformerGroup = ({
 
         <div className="flex-1" />
 
-        <EditorResetButton<CopilotDocV1.Action>
-          reset={reset}
-          entityName="干员组"
-        />
+        <EditorResetButton reset={reset} entityName="干员组" />
       </div>
 
-      <FormField2 label="干员组名" field="name" error={errors.name} asterisk>
-        <EditorOperatorSelect<CopilotDocV1.Group>
-          control={control}
-          name="name"
-        />
-      </FormField2>
+      <FormField
+        label="干员组名"
+        field="name"
+        control={control}
+        error={errors.name}
+        ControllerProps={{
+          rules: { validate: (value) => !!value.trim() || '请输入干员组名' },
+          render: ({ field }) => (
+            <InputGroup
+              large
+              placeholder="任意名称，用于在动作中引用。例如：速狙、群奶"
+              {...field}
+            />
+          ),
+        }}
+      />
 
       <Button
         disabled={!isValid && !isDirty}

--- a/src/components/editor/operator/EditorPerformerOperator.tsx
+++ b/src/components/editor/operator/EditorPerformerOperator.tsx
@@ -2,23 +2,37 @@ import { Button } from '@blueprintjs/core'
 import { CardTitle } from 'components/CardTitle'
 import { EditorResetButton } from 'components/editor/EditorResetButton'
 import { SubmitHandler, useForm } from 'react-hook-form'
+import { handleFieldError } from '../../../utils/fieldError'
 import { EditorOperator } from './EditorOperator'
-import { EditorPerformerChildProps } from './EditorPerformer'
+
+export interface EditorPerformerOperatorProps {
+  submit: (operator: CopilotDocV1.Operator) => void
+  categorySelector: JSX.Element
+}
 
 export const EditorPerformerOperator = ({
   submit,
   categorySelector,
-}: EditorPerformerChildProps) => {
+}: EditorPerformerOperatorProps) => {
   const {
     control,
     reset,
     handleSubmit,
+    setError,
     formState: { errors, isValid, isDirty },
   } = useForm<CopilotDocV1.Operator>()
 
   const onSubmit: SubmitHandler<CopilotDocV1.Operator> = (values) => {
-    submit(values)
-    reset()
+    try {
+      submit({
+        ...values,
+        name: values.name.trim(),
+      })
+      reset()
+    } catch (e) {
+      handleFieldError(setError, e)
+      console.warn(e)
+    }
   }
 
   return (

--- a/src/models/copilot.schema.ts
+++ b/src/models/copilot.schema.ts
@@ -52,7 +52,7 @@ namespace CopilotDocV1 {
     )
 
   export interface ActionSkillUsage extends ActionBase {
-    skillUsage: number
+    skillUsage: SkillUsageType
     type: Type.SkillUsage
   }
 
@@ -107,8 +107,10 @@ namespace CopilotDocV1 {
      * 可选，默认 1，取值范围 [1, 3]
      */
     skill?: number
-    skillUsage?: number
+    skillUsage?: SkillUsageType
   }
+
+  export type SkillUsageType = 0 | 1 | 2 | 3
 
   export interface Requirements {
     elite?: number

--- a/src/models/operator.ts
+++ b/src/models/operator.ts
@@ -1,0 +1,50 @@
+import {
+  DetailedSelectChoice,
+  DetailedSelectItem,
+  isChoice,
+} from '../components/editor/DetailedSelect'
+
+const defaultValue: CopilotDocV1.SkillUsageType = 0
+
+export type DetailedOperatorSkillUsage = DetailedSelectChoice
+
+export const operatorSkillUsages: DetailedSelectItem[] = [
+  {
+    type: 'choice',
+    icon: 'disable',
+    title: '不自动使用',
+    value: 0,
+    description:
+      '不由 MAA Copilot 自动开启技能、或干员技能并不需要操作开启（自动触发）。若需要手动开启技能，请添加「使用技能」动作',
+  },
+  {
+    type: 'choice',
+    icon: 'automatic-updates',
+    title: '好了就用，有多少次用多少次',
+    value: 1,
+    description: '例如：棘刺 3 技能、桃金娘 1 技能等',
+  },
+  {
+    type: 'choice',
+    icon: 'circle',
+    title: '好了就用，仅使用一次',
+    value: 2,
+    description: '例如：山 2 技能',
+  },
+  {
+    type: 'choice',
+    icon: 'predictive-analysis',
+    title: '自动判断使用时机',
+    value: 3,
+    description: '(锐意开发中) 画饼.jpg',
+    disabled: true,
+  },
+]
+
+export function findOperatorSkillUsage(
+  value: number = defaultValue,
+): DetailedOperatorSkillUsage | undefined {
+  return operatorSkillUsages
+    .filter(isChoice)
+    .find((item) => item.value === value)
+}

--- a/src/utils/fieldError.ts
+++ b/src/utils/fieldError.ts
@@ -1,0 +1,16 @@
+import { FieldValues, Path, UseFormSetError } from 'react-hook-form'
+
+export class FieldError extends Error {
+  constructor(public field: string, message: string) {
+    super(message)
+  }
+}
+
+export function handleFieldError<T extends FieldValues>(
+  setError: UseFormSetError<T>,
+  error: unknown,
+) {
+  if (error instanceof FieldError) {
+    setError(error.field as Path<T>, { message: error.message })
+  }
+}


### PR DESCRIPTION
更新：回退了一下，现在这个 PR 的内容如下：

- 增加干员和干员组卡片，可以通过拖拽来分配干员到干员组内
- 修复关卡输入框无法搜索的问题，这个 commit 很简单，所以就不新开一个 PR 了
- 在 CI preview 上禁用掉施工中的 overlay