### PR TITLE
refactor(editor): code structure & typing improvements

### DIFF
--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -70,7 +70,7 @@ export const FormField = <T extends FieldValues, P extends Path<T>>({
   )
 }
 
-export interface FormField2Props<T> {
+export interface FormField2Props<T extends FieldValues> {
   FormGroupProps?: Omit<FormGroupProps, 'label' | 'labelFor'>
   className?: string
   error?: any
@@ -80,7 +80,7 @@ export interface FormField2Props<T> {
   description?: Tooltip2Props['content']
 }
 
-export const FormField2 = <T,>({
+export const FormField2 = <T extends FieldValues>({
   FormGroupProps,
   className,
   error,

--- a/src/components/editor/EditorFieldProps.tsx
+++ b/src/components/editor/EditorFieldProps.tsx
@@ -14,30 +14,59 @@ type PathOfType<T, P extends Path<T> | ArrayPath<T>, U> = P extends any
     : never
   : never
 
+/**
+ * Declares a props type for Controller, the `name` of which is the paths to properties
+ * that satisfy the type `TType`.
+ *
+ * @example
+ * ```tsx
+ * type A = { a: number, b: { c: number }, d: string }
+ *
+ * function foo({ name, control }: EditorFieldProps<A, number>) {
+ *  // name is 'a' | 'b.c'
+ *
+ *  const { field: { value } } = useController({ name, control })
+ *  // value is number
+ * }
+ * ```
+ *
+ * Unfortunately this does not work well with a generic input, as below:
+ *
+ * @example
+ * ```tsx
+ * type A = { a: number, b: number, c: string }
+ *
+ * function foo<T extends A>({ name, control }: EditorFieldProps<T, number>) {
+ *  // name is never
+ *
+ *  const { field: { value } } = useController({ name, control })
+ *  // value is never
+ *
+ *  // so you'll need a type assertion when using value...
+ *  ;(value as string).length
+ * }
+ * ```
+ */
 export interface EditorFieldProps<
   TFieldValues extends FieldValues,
   TType = any,
 > extends UseControllerProps<
     TFieldValues,
-    string extends keyof TFieldValues
-      ? never
-      : // the Cast here is a workaround for the fact that TS cannot correctly recognize
-        // that ConditionalPick returns a subset of TFieldValues
-        // refer to: https://github.com/microsoft/TypeScript/issues/46855#issuecomment-974484444
-        Cast<
-          PathOfType<
-            // wrap in Require to prevent optional keys from being stripped
-            Required<TFieldValues>,
-            FieldPath<Required<TFieldValues>>,
-            TType
-          >,
-          FieldPath<TFieldValues>
-        >
+    // the Cast here is a workaround for the fact that TS cannot correctly recognize
+    // that the result of PathOfType is assignable to FieldPath<TFieldValues>
+    // refer to: https://github.com/microsoft/TypeScript/issues/46855#issuecomment-974484444
+    Cast<
+      PathOfType<
+        // wrap in Require to prevent optional keys from being stripped
+        Required<TFieldValues>,
+        FieldPath<Required<TFieldValues>>,
+        TType
+      >,
+      FieldPath<TFieldValues>
+    >
   > {}
 
 export interface EditorFieldPropsByName<
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
-> extends UseControllerProps<TFieldValues, TName> {
-  error?: any
-}
+> extends UseControllerProps<TFieldValues, TName> {}

--- a/src/components/editor/EditorFieldProps.tsx
+++ b/src/components/editor/EditorFieldProps.tsx
@@ -33,9 +33,7 @@ export interface EditorFieldProps<
           >,
           FieldPath<TFieldValues>
         >
-  > {
-  error?: any
-}
+  > {}
 
 export interface EditorFieldPropsByName<
   TFieldValues extends FieldValues = FieldValues,

--- a/src/components/editor/EditorFieldProps.tsx
+++ b/src/components/editor/EditorFieldProps.tsx
@@ -1,6 +1,45 @@
-import { UseControllerProps } from 'react-hook-form'
+import {
+  ArrayPath,
+  FieldPath,
+  FieldValues,
+  Path,
+  PathValue,
+  UseControllerProps,
+} from 'react-hook-form'
+import { Cast } from '../../types'
 
-export interface EditorFieldProps<T> {
-  name: UseControllerProps<T>['name']
-  control: UseControllerProps<T>['control']
+type PathOfType<T, P extends Path<T> | ArrayPath<T>, U> = P extends any
+  ? PathValue<T, P> extends U
+    ? P
+    : never
+  : never
+
+export interface EditorFieldProps<
+  TFieldValues extends FieldValues,
+  TType = any,
+> extends UseControllerProps<
+    TFieldValues,
+    string extends keyof TFieldValues
+      ? never
+      : // the Cast here is a workaround for the fact that TS cannot correctly recognize
+        // that ConditionalPick returns a subset of TFieldValues
+        // refer to: https://github.com/microsoft/TypeScript/issues/46855#issuecomment-974484444
+        Cast<
+          PathOfType<
+            // wrap in Require to prevent optional keys from being stripped
+            Required<TFieldValues>,
+            FieldPath<Required<TFieldValues>>,
+            TType
+          >,
+          FieldPath<TFieldValues>
+        >
+  > {
+  error?: any
+}
+
+export interface EditorFieldPropsByName<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> extends UseControllerProps<TFieldValues, TName> {
+  error?: any
 }

--- a/src/components/editor/EditorIntegerInput.tsx
+++ b/src/components/editor/EditorIntegerInput.tsx
@@ -1,15 +1,16 @@
 import { NumericInput, NumericInputProps } from '@blueprintjs/core'
 import { EditorFieldProps } from 'components/editor/EditorFieldProps'
-import { useController } from 'react-hook-form'
+import { FieldValues, useController } from 'react-hook-form'
 
-export interface EditorIntegerInputProps<T> extends EditorFieldProps<T> {
+export interface EditorIntegerInputProps<T extends FieldValues>
+  extends EditorFieldProps<T, number> {
   NumericInputProps: Omit<
     NumericInputProps,
     'name' | 'inputRef' | 'onValueChange' | 'onBlur'
   >
 }
 
-export const EditorIntegerInput = <T,>({
+export const EditorIntegerInput = <T extends FieldValues>({
   name,
   control,
   NumericInputProps,
@@ -42,7 +43,6 @@ export const EditorIntegerInput = <T,>({
         onChange(value)
       }}
       onBlur={onBlur}
-      // @ts-ignore: TODO: improve generics usage to solve this typing problem
       value={value ?? ''}
       // seems that NumericInput component have a bug where if
       // passed an undefined value, it's just simply not gonna update anymore...

--- a/src/components/editor/EditorResetButton.tsx
+++ b/src/components/editor/EditorResetButton.tsx
@@ -1,8 +1,8 @@
 import { Alert, Button, H4 } from '@blueprintjs/core'
 import { useState } from 'react'
-import { UseFormReset } from 'react-hook-form'
+import { FieldValues, UseFormReset } from 'react-hook-form'
 
-export const EditorResetButton = <T,>({
+export const EditorResetButton = <T extends FieldValues>({
   reset,
   entityName,
 }: {

--- a/src/components/editor/action/EditorActionAdd.tsx
+++ b/src/components/editor/action/EditorActionAdd.tsx
@@ -16,12 +16,6 @@ import {
   useForm,
   useWatch,
 } from 'react-hook-form'
-import type {
-  Control,
-  UseFormGetValues,
-  FieldErrorsImpl,
-  DeepRequired,
-} from 'react-hook-form'
 
 export interface EditorActionAddProps {
   append: UseFieldArrayAppend<CopilotDocV1.Action>
@@ -31,7 +25,6 @@ export const EditorActionAdd = ({ append }: EditorActionAddProps) => {
   const {
     control,
     reset,
-    getValues,
     handleSubmit,
     formState: { errors, isValid, isDirty },
   } = useForm<CopilotDocV1.Action>()
@@ -80,77 +73,33 @@ export const EditorActionAdd = ({ append }: EditorActionAddProps) => {
         {(type === 'Deploy' || type === 'Skill' || type === 'Retreat') && (
           <>
             <div className="flex">
-              <EditorActionExecPredicateKills
-                control={control}
-                error={errors.kills}
-              />
-
-              <EditorActionExecPredicateCostChange
-                control={control}
-                error={errors.costChanges}
-              />
+              <EditorActionExecPredicateKills control={control} />
+              <EditorActionExecPredicateCostChange control={control} />
             </div>
 
             <div className="flex">
-              <FormField2
-                label="干员位置"
-                field="location"
-                error={
-                  (
-                    errors as FieldErrorsImpl<
-                      DeepRequired<
-                        | CopilotDocV1.ActionDeploy
-                        | CopilotDocV1.ActionSkillOrRetreat
-                      >
-                    >
-                  ).location
-                }
-                description="填完关卡名后开一局，会在目录下 map 文件夹中生成地图坐标图片"
-                className="mr-4"
-              >
-                <EditorActionOperatorLocation
-                  control={control}
-                  name="location"
-                  getValues={
-                    getValues as UseFormGetValues<
-                      | CopilotDocV1.ActionDeploy
-                      | CopilotDocV1.ActionSkillOrRetreat
-                    >
-                  }
-                />
-              </FormField2>
+              <EditorActionOperatorLocation
+                actionType={type}
+                control={control}
+                name="location"
+              />
             </div>
           </>
         )}
 
         {type === 'Deploy' && (
           <div className="flex">
-            <FormField2
-              label="干员朝向"
-              field="direction"
-              error={
-                (
-                  errors as FieldErrorsImpl<
-                    DeepRequired<CopilotDocV1.ActionDeploy>
-                  >
-                ).direction
-              }
-              description="部署干员的干员朝向"
-            >
-              <EditorActionOperatorDirection<CopilotDocV1.ActionDeploy>
-                control={control as Control<CopilotDocV1.ActionDeploy, object>}
-                name="direction"
-                getValues={
-                  getValues as UseFormGetValues<CopilotDocV1.ActionDeploy>
-                }
-              />
-            </FormField2>
+            <EditorActionOperatorDirection
+              control={control}
+              name="direction"
+              actionType={type}
+            />
           </div>
         )}
 
         <div className="flex">
           <div className="w-full">
-            <FormField<CopilotDocV1.Action>
+            <FormField
               label="描述"
               field="doc"
               control={control}

--- a/src/components/editor/action/EditorActionAdd.tsx
+++ b/src/components/editor/action/EditorActionAdd.tsx
@@ -80,30 +80,15 @@ export const EditorActionAdd = ({ append }: EditorActionAddProps) => {
         {(type === 'Deploy' || type === 'Skill' || type === 'Retreat') && (
           <>
             <div className="flex">
-              <FormField2
-                label="击杀数条件"
-                className="mr-2 lg:mr-4"
-                field="kills"
+              <EditorActionExecPredicateKills
+                control={control}
                 error={errors.kills}
-                description="击杀数条件，如果没达到就一直等待。可选，默认为 0，直接执行"
-              >
-                <EditorActionExecPredicateKills<CopilotDocV1.Action>
-                  name="kills"
-                  control={control}
-                />
-              </FormField2>
+              />
 
-              <FormField2
-                label="费用变化量条件"
-                field="costChanges"
+              <EditorActionExecPredicateCostChange
+                control={control}
                 error={errors.costChanges}
-                description="费用变化量，如果没达到就一直等待。可选，默认为 0，直接执行。注意：费用变化量是从开始执行本动作时开始计算的（即：使用前一个动作结束时的费用作为基准）；另外仅在费用是两位数的时候识别的比较准，三位数的费用可能会识别错，不推荐使用"
-              >
-                <EditorActionExecPredicateCostChange<CopilotDocV1.Action>
-                  name="costChanges"
-                  control={control}
-                />
-              </FormField2>
+              />
             </div>
 
             <div className="flex">
@@ -123,16 +108,8 @@ export const EditorActionAdd = ({ append }: EditorActionAddProps) => {
                 description="填完关卡名后开一局，会在目录下 map 文件夹中生成地图坐标图片"
                 className="mr-4"
               >
-                <EditorActionOperatorLocation<
-                  CopilotDocV1.ActionDeploy | CopilotDocV1.ActionSkillOrRetreat
-                >
-                  control={
-                    control as Control<
-                      | CopilotDocV1.ActionDeploy
-                      | CopilotDocV1.ActionSkillOrRetreat,
-                      object
-                    >
-                  }
+                <EditorActionOperatorLocation
+                  control={control}
                   name="location"
                   getValues={
                     getValues as UseFormGetValues<

--- a/src/components/editor/action/EditorActionAdd.tsx
+++ b/src/components/editor/action/EditorActionAdd.tsx
@@ -46,10 +46,7 @@ export const EditorActionAdd = ({ append }: EditorActionAddProps) => {
 
           <div className="flex-1" />
 
-          <EditorResetButton<CopilotDocV1.Action>
-            reset={reset}
-            entityName="动作"
-          />
+          <EditorResetButton reset={reset} entityName="动作" />
         </div>
 
         {import.meta.env.DEV && <DevTool control={control} />}
@@ -62,10 +59,7 @@ export const EditorActionAdd = ({ append }: EditorActionAddProps) => {
               error={errors.type}
               asterisk
             >
-              <EditorActionTypeSelect<CopilotDocV1.Action>
-                control={control}
-                name="type"
-              />
+              <EditorActionTypeSelect control={control} name="type" />
             </FormField2>
           </div>
         </div>

--- a/src/components/editor/action/EditorActionExecPredicate.tsx
+++ b/src/components/editor/action/EditorActionExecPredicate.tsx
@@ -1,36 +1,50 @@
 import { EditorFieldProps } from 'components/editor/EditorFieldProps'
-import {
-  EditorIntegerInput,
-  EditorIntegerInputProps,
-} from 'components/editor/EditorIntegerInput'
+import { EditorIntegerInput } from 'components/editor/EditorIntegerInput'
+import { SetOptional } from 'type-fest'
+import { FormField2 } from '../../FormField'
 
-interface EditorActionExecPredicateProps<T> extends EditorFieldProps<T> {
-  NumericInputProps?: Omit<
-    EditorIntegerInputProps<T>['NumericInputProps'],
-    'placeholder'
-  >
-}
+interface EditorActionExecPredicateProps
+  extends SetOptional<EditorFieldProps<CopilotDocV1.Action, number>, 'name'> {}
 
-export const EditorActionExecPredicateKills = <T,>({
-  name,
+export const EditorActionExecPredicateKills = ({
+  name = 'kills',
   control,
-  NumericInputProps,
-}: EditorActionExecPredicateProps<T>) => (
-  <EditorIntegerInput
-    NumericInputProps={{ placeholder: '击杀数', ...NumericInputProps }}
-    control={control}
-    name={name}
-  />
+  rules,
+  error,
+}: EditorActionExecPredicateProps) => (
+  <FormField2
+    label="击杀数条件"
+    className="mr-2 lg:mr-4"
+    field={name}
+    error={error}
+    description="击杀数条件，如果没达到就一直等待。可选，默认为 0，直接执行"
+  >
+    <EditorIntegerInput
+      NumericInputProps={{ placeholder: '击杀数' }}
+      control={control}
+      name={name}
+      rules={rules}
+    />
+  </FormField2>
 )
 
-export const EditorActionExecPredicateCostChange = <T,>({
-  name,
+export const EditorActionExecPredicateCostChange = ({
+  name = 'costChanges',
   control,
-  NumericInputProps,
-}: EditorActionExecPredicateProps<T>) => (
-  <EditorIntegerInput
-    NumericInputProps={{ placeholder: '费用变化量', ...NumericInputProps }}
-    control={control}
-    name={name}
-  />
+  rules,
+  error,
+}: EditorActionExecPredicateProps) => (
+  <FormField2
+    label="费用变化量条件"
+    field={name}
+    error={error}
+    description="费用变化量，如果没达到就一直等待。可选，默认为 0，直接执行。注意：费用变化量是从开始执行本动作时开始计算的（即：使用前一个动作结束时的费用作为基准）；另外仅在费用是两位数的时候识别的比较准，三位数的费用可能会识别错，不推荐使用"
+  >
+    <EditorIntegerInput
+      NumericInputProps={{ placeholder: '费用变化量' }}
+      control={control}
+      name={name}
+      rules={rules}
+    />
+  </FormField2>
 )

--- a/src/components/editor/action/EditorActionExecPredicate.tsx
+++ b/src/components/editor/action/EditorActionExecPredicate.tsx
@@ -1,5 +1,6 @@
 import { EditorFieldProps } from 'components/editor/EditorFieldProps'
 import { EditorIntegerInput } from 'components/editor/EditorIntegerInput'
+import { useFormState } from 'react-hook-form'
 import { SetOptional } from 'type-fest'
 import { FormField2 } from '../../FormField'
 
@@ -10,41 +11,47 @@ export const EditorActionExecPredicateKills = ({
   name = 'kills',
   control,
   rules,
-  error,
-}: EditorActionExecPredicateProps) => (
-  <FormField2
-    label="击杀数条件"
-    className="mr-2 lg:mr-4"
-    field={name}
-    error={error}
-    description="击杀数条件，如果没达到就一直等待。可选，默认为 0，直接执行"
-  >
-    <EditorIntegerInput
-      NumericInputProps={{ placeholder: '击杀数' }}
-      control={control}
-      name={name}
-      rules={rules}
-    />
-  </FormField2>
-)
+}: EditorActionExecPredicateProps) => {
+  const { errors } = useFormState({ control, name })
+
+  return (
+    <FormField2
+      label="击杀数条件"
+      className="mr-2 lg:mr-4"
+      field={name}
+      error={errors[name]}
+      description="击杀数条件，如果没达到就一直等待。可选，默认为 0，直接执行"
+    >
+      <EditorIntegerInput
+        NumericInputProps={{ placeholder: '击杀数' }}
+        control={control}
+        name={name}
+        rules={rules}
+      />
+    </FormField2>
+  )
+}
 
 export const EditorActionExecPredicateCostChange = ({
   name = 'costChanges',
   control,
   rules,
-  error,
-}: EditorActionExecPredicateProps) => (
-  <FormField2
-    label="费用变化量条件"
-    field={name}
-    error={error}
-    description="费用变化量，如果没达到就一直等待。可选，默认为 0，直接执行。注意：费用变化量是从开始执行本动作时开始计算的（即：使用前一个动作结束时的费用作为基准）；另外仅在费用是两位数的时候识别的比较准，三位数的费用可能会识别错，不推荐使用"
-  >
-    <EditorIntegerInput
-      NumericInputProps={{ placeholder: '费用变化量' }}
-      control={control}
-      name={name}
-      rules={rules}
-    />
-  </FormField2>
-)
+}: EditorActionExecPredicateProps) => {
+  const { errors } = useFormState({ control, name })
+
+  return (
+    <FormField2
+      label="费用变化量条件"
+      field={name}
+      error={errors[name]}
+      description="费用变化量，如果没达到就一直等待。可选，默认为 0，直接执行。注意：费用变化量是从开始执行本动作时开始计算的（即：使用前一个动作结束时的费用作为基准）；另外仅在费用是两位数的时候识别的比较准，三位数的费用可能会识别错，不推荐使用"
+    >
+      <EditorIntegerInput
+        NumericInputProps={{ placeholder: '费用变化量' }}
+        control={control}
+        name={name}
+        rules={rules}
+      />
+    </FormField2>
+  )
+}

--- a/src/components/editor/action/EditorActionOperatorDirection.tsx
+++ b/src/components/editor/action/EditorActionOperatorDirection.tsx
@@ -2,33 +2,35 @@ import { Button, IconName, MenuItem } from '@blueprintjs/core'
 import { Select2 } from '@blueprintjs/select'
 import { EditorFieldProps } from 'components/editor/EditorFieldProps'
 import { useMemo } from 'react'
-import { useController, UseFormGetValues } from 'react-hook-form'
+import { useController } from 'react-hook-form'
+import { SetOptional } from 'type-fest'
+import { FormField2 } from '../../FormField'
 
 interface EditorActionOperatorDirectionChoice {
   icon?: IconName
   title: string
   value: string | null
 }
-const EditorActionOperatorDirectionSelect =
-  Select2.ofType<EditorActionOperatorDirectionChoice>()
 
-interface EditorActionOperatorDirectionProps<T> extends EditorFieldProps<T> {
-  getValues: UseFormGetValues<T>
+interface EditorActionOperatorDirectionProps
+  extends SetOptional<EditorFieldProps<CopilotDocV1.Action>, 'name'> {
+  actionType: CopilotDocV1.Type
 }
 
-export const EditorActionOperatorDirection = <T extends { type?: string }>({
-  name,
+export const EditorActionOperatorDirection = ({
+  name = 'direction',
   control,
-  getValues,
-}: EditorActionOperatorDirectionProps<T>) => {
+  actionType,
+}: EditorActionOperatorDirectionProps) => {
   const {
     field: { onChange, onBlur, value, ref },
+    formState: { errors },
   } = useController({
     name,
     control,
     rules: {
       validate: (v) => {
-        if (getValues().type === 'Deploy' && !v) return '部署动作下必须选择朝向'
+        if (actionType === 'Deploy' && !v) return '部署动作下必须选择朝向'
         return true
       },
     },
@@ -68,30 +70,37 @@ export const EditorActionOperatorDirection = <T extends { type?: string }>({
   const selected = items.find((item) => item.value === (value ?? null))
 
   return (
-    <EditorActionOperatorDirectionSelect
-      filterable={false}
-      items={items}
-      itemRenderer={(action, { handleClick, handleFocus, modifiers }) => (
-        <MenuItem
-          selected={modifiers.active}
-          key={action.value}
-          onClick={handleClick}
-          onFocus={handleFocus}
-          icon={action.icon}
-          text={action.title}
-        />
-      )}
-      onItemSelect={(item) => {
-        onChange(item.value)
-      }}
+    <FormField2
+      label="干员朝向"
+      field={name}
+      error={errors[name]}
+      description="部署干员的干员朝向"
     >
-      <Button
-        icon={selected?.icon}
-        text={selected?.title}
-        rightIcon="double-caret-vertical"
-        onBlur={onBlur}
-        ref={ref}
-      />
-    </EditorActionOperatorDirectionSelect>
+      <Select2
+        filterable={false}
+        items={items}
+        itemRenderer={(action, { handleClick, handleFocus, modifiers }) => (
+          <MenuItem
+            selected={modifiers.active}
+            key={action.value}
+            onClick={handleClick}
+            onFocus={handleFocus}
+            icon={action.icon}
+            text={action.title}
+          />
+        )}
+        onItemSelect={(item) => {
+          onChange(item.value)
+        }}
+      >
+        <Button
+          icon={selected?.icon}
+          text={selected?.title}
+          rightIcon="double-caret-vertical"
+          onBlur={onBlur}
+          ref={ref}
+        />
+      </Select2>
+    </FormField2>
   )
 }

--- a/src/components/editor/action/EditorActionOperatorLocation.tsx
+++ b/src/components/editor/action/EditorActionOperatorLocation.tsx
@@ -2,15 +2,16 @@ import { InputGroup } from '@blueprintjs/core'
 import { EditorFieldProps } from 'components/editor/EditorFieldProps'
 import { useController, UseFormGetValues } from 'react-hook-form'
 
-interface EditorActionOperatorLocationProps<T> extends EditorFieldProps<T> {
-  getValues: UseFormGetValues<T>
+interface EditorActionOperatorLocationProps
+  extends EditorFieldProps<CopilotDocV1.Action, [number, number]> {
+  getValues: UseFormGetValues<CopilotDocV1.Action>
 }
 
-export const EditorActionOperatorLocation = <T extends { type?: string }>({
+export const EditorActionOperatorLocation = ({
   name,
   control,
   getValues,
-}: EditorActionOperatorLocationProps<T>) => {
+}: EditorActionOperatorLocationProps) => {
   const {
     field: { onChange, value },
   } = useController({

--- a/src/components/editor/action/EditorActionOperatorLocation.tsx
+++ b/src/components/editor/action/EditorActionOperatorLocation.tsx
@@ -1,26 +1,28 @@
 import { InputGroup } from '@blueprintjs/core'
 import { EditorFieldProps } from 'components/editor/EditorFieldProps'
-import { useController, UseFormGetValues } from 'react-hook-form'
+import { useController } from 'react-hook-form'
+import { FormField2 } from '../../FormField'
 
 interface EditorActionOperatorLocationProps
   extends EditorFieldProps<CopilotDocV1.Action, [number, number]> {
-  getValues: UseFormGetValues<CopilotDocV1.Action>
+  actionType: CopilotDocV1.Type
 }
 
 export const EditorActionOperatorLocation = ({
   name,
   control,
-  getValues,
+  actionType,
 }: EditorActionOperatorLocationProps) => {
   const {
     field: { onChange, value },
+    formState: { errors },
   } = useController({
     name,
     control,
     rules: {
       validate: (v) => {
         if (
-          getValues().type === 'Deploy' &&
+          actionType === 'Deploy' &&
           (!v ||
             !Array.isArray(v) ||
             v.length !== 2 ||
@@ -46,19 +48,31 @@ export const EditorActionOperatorLocation = ({
   }
 
   return (
-    <div className="flex">
-      <InputGroup
-        onChange={(v) => onChange(transform.fromX(castInteger(v.target.value)))}
-        value={converted[0] === 0 ? '' : converted[0].toString()}
-        placeholder="X 坐标"
-        className="mr-2"
-      />
-      <InputGroup
-        onChange={(v) => onChange(transform.fromY(castInteger(v.target.value)))}
-        value={converted[1] === 0 ? '' : converted[1].toString()}
-        placeholder="Y 坐标"
-      />
-    </div>
+    <FormField2
+      label="干员位置"
+      field="location"
+      error={errors[name]}
+      description="填完关卡名后开一局，会在目录下 map 文件夹中生成地图坐标图片"
+      className="mr-4"
+    >
+      <div className="flex">
+        <InputGroup
+          onChange={(v) =>
+            onChange(transform.fromX(castInteger(v.target.value)))
+          }
+          value={converted[0] === 0 ? '' : converted[0].toString()}
+          placeholder="X 坐标"
+          className="mr-2"
+        />
+        <InputGroup
+          onChange={(v) =>
+            onChange(transform.fromY(castInteger(v.target.value)))
+          }
+          value={converted[1] === 0 ? '' : converted[1].toString()}
+          placeholder="Y 坐标"
+        />
+      </div>
+    </FormField2>
   )
 }
 

--- a/src/components/editor/action/EditorActionTypeSelect.tsx
+++ b/src/components/editor/action/EditorActionTypeSelect.tsx
@@ -8,10 +8,10 @@ import { EditorFieldProps } from 'components/editor/EditorFieldProps'
 import { useMemo } from 'react'
 import { useController } from 'react-hook-form'
 
-export const EditorActionTypeSelect = <T,>({
+export const EditorActionTypeSelect = ({
   name,
   control,
-}: EditorFieldProps<T>) => {
+}: EditorFieldProps<CopilotDocV1.Action, CopilotDocV1.Type>) => {
   const {
     field: { onChange, onBlur, value, ref },
   } = useController({

--- a/src/components/editor/operator/EditorOperator.tsx
+++ b/src/components/editor/operator/EditorOperator.tsx
@@ -36,10 +36,7 @@ export const EditorOperator: FC<{
           error={errors.skill}
           className="mr-2"
         >
-          <EditorOperatorSkill<CopilotDocV1.Operator>
-            control={control}
-            name="skill"
-          />
+          <EditorOperatorSkill control={control} name="skill" />
         </FormField2>
 
         <FormField2
@@ -47,10 +44,7 @@ export const EditorOperator: FC<{
           field="skillUsage"
           error={errors.skillUsage}
         >
-          <EditorOperatorSkillUsage<CopilotDocV1.Operator>
-            control={control}
-            name="skillUsage"
-          />
+          <EditorOperatorSkillUsage control={control} name="skillUsage" />
         </FormField2>
       </div>
     </>
@@ -72,7 +66,7 @@ const EditorOperatorName = <T extends FieldValues>({
 }: EditorFieldProps<T>) => {
   const {
     field: { onChange, onBlur, value, ref },
-  } = useController<T>({
+  } = useController({
     name,
     control,
     rules: { required: '请输入干员名' },

--- a/src/components/editor/operator/EditorOperatorSelect.tsx
+++ b/src/components/editor/operator/EditorOperatorSelect.tsx
@@ -6,9 +6,9 @@ import {
 } from 'components/editor/DetailedSelect'
 import { EditorFieldProps } from 'components/editor/EditorFieldProps'
 import { useMemo } from 'react'
-import { useController } from 'react-hook-form'
+import { FieldValues, useController } from 'react-hook-form'
 
-export const EditorOperatorSelect = <T,>({
+export const EditorOperatorSelect = <T extends FieldValues>({
   name,
   control,
 }: EditorFieldProps<T>) => {

--- a/src/components/editor/operator/EditorOperatorSkill.tsx
+++ b/src/components/editor/operator/EditorOperatorSkill.tsx
@@ -11,12 +11,13 @@ interface EditorOperatorSkillChoice {
 }
 const EditorOperatorSkillSelect = Select2.ofType<EditorOperatorSkillChoice>()
 
-interface EditorOperatorSkillProps<T> extends EditorFieldProps<T> {}
+interface EditorOperatorSkillProps
+  extends EditorFieldProps<CopilotDocV1.Operator, number> {}
 
-export const EditorOperatorSkill = <T,>({
+export const EditorOperatorSkill = ({
   name,
   control,
-}: EditorOperatorSkillProps<T>) => {
+}: EditorOperatorSkillProps) => {
   const {
     field: { onChange, onBlur, value, ref },
   } = useController({

--- a/src/components/editor/operator/EditorOperatorSkillUsage.tsx
+++ b/src/components/editor/operator/EditorOperatorSkillUsage.tsx
@@ -7,10 +7,10 @@ import { EditorFieldProps } from 'components/editor/EditorFieldProps'
 import { useController } from 'react-hook-form'
 import { operatorSkillUsages } from '../../../models/operator'
 
-export const EditorOperatorSkillUsage = <T,>({
+export const EditorOperatorSkillUsage = ({
   name,
   control,
-}: EditorFieldProps<T>) => {
+}: EditorFieldProps<CopilotDocV1.Operator, CopilotDocV1.SkillUsageType>) => {
   const {
     field: { onChange, onBlur, value, ref },
   } = useController({

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,2 +1,4 @@
 export type WithChildren<T> = T & { children?: React.ReactNode }
 export type FCC<T = {}> = React.FC<WithChildren<T>>
+
+export type Cast<T, U> = T extends U ? T : T & U


### PR DESCRIPTION
1. 调整了一下 action form 里的代码结构，把用来包裹自定义组件的 FormField2 都纳入到这些自定义组件里面

好难描述啊草，大概像这样：

```jsx
<FormField2>
  <MyInput/>
</FormField2>
```

调整后变成这样

```jsx
<MyInput/> // 把 FormField2 放到组件里面去了
```

2. 优化了 `EditorFieldProps` 的定义，且用来优化了一些别的类型

这个类型现在可以通过第二个泛型参数来指定其 `name` 对应的 `value` 的类型，例如：

```ts
type A = {
  a: number,
  b: { 
    c: number
  },
  d: string
}

function foo({ name, control }: EditorFieldProps<A, number>) {
 // name is 'a' | 'b.c'

 const { field: { value } } = useController({ name, control })
 // value is number
}
```

有个缺点是当第一个泛型参数自身也是个泛型时，`name` 和 `value` 都会被推导为 `never`，不过影响不大，cast 一下就好了
