### PR TITLE
fix: 修复颜色错误

### DIFF
--- a/src/models/operator.ts
+++ b/src/models/operator.ts
@@ -142,11 +142,11 @@ export const actionDocColors: ActionDocColor[] = [
   },
   {
     title: '黄色',
-    value: 'Glod',
+    value: 'Gold',
   },
   {
     title: '绿色',
-    value: '#198754',
+    value: 'SpringGreen',
   },
   {
     title: '青色',


### PR DESCRIPTION
1. 黄色的 typo
2. 绿色和青色区别不明显，换个翠绿一点的

![image](https://user-images.githubusercontent.com/18511905/193917014-b7a5c8a3-ed36-4c96-9baf-c1c55a8d710a.png)
