### PR TITLE
查找作业防抖时间延长

### DIFF
--- a/src/components/Operations.tsx
+++ b/src/components/Operations.tsx
@@ -23,7 +23,7 @@ export const Operations: ComponentType = withSuspensable(() => {
     orderBy: 'hot',
   })
   const debouncedSetQueryParams = useMemo(
-    () => debounce(setQueryParams, 250),
+    () => debounce(setQueryParams, 500),
     [],
   )
   const [authState] = useAtom(authAtom)


### PR DESCRIPTION
把查找作业的防抖时间延长一倍，希望能降低后端压力。
目前查找作业除了间隔时间太短之外，还会向后端发送两次参数一致的请求，但本人不是很懂React，找不出问题所在，只能先延长间隔。