### PR TITLE
feat: refactor OperatorSelect to prevent duplicate selections

### DIFF
--- a/src/components/OperatorSelect.tsx
+++ b/src/components/OperatorSelect.tsx
@@ -78,7 +78,11 @@ export const OperatorSelect: FC<OperatorSelectProps> = ({
   }
 
   const add = (operation: OperatorInfo) => {
-    change([...new Set([...operators, { name: operation.name }])])
+    if (!operators.some((op) => op.name === operation.name)) {
+      change([...operators, { name: operation.name }])
+    } else {
+      remove(operation)
+    }
   }
 
   const remove = (operation: OperatorInfo) => {


### PR DESCRIPTION
The add function in OperatorSelect now checks if the selected operator is already in the list of operators. If it is, the function removes the operator from the list. This prevents duplicate selections in the component.