### PR TITLE
feat: selected operators are now persisted by jotai atoms

### DIFF
--- a/src/components/Operations.tsx
+++ b/src/components/Operations.tsx
@@ -7,7 +7,7 @@ import {
 } from '@blueprintjs/core'
 
 import { UseOperationsParams } from 'apis/operation'
-import { useAtom } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 import { debounce } from 'lodash-es'
 import { ComponentType, useMemo, useState } from 'react'
 
@@ -15,15 +15,25 @@ import { CardTitle } from 'components/CardTitle'
 import { OperationList } from 'components/OperationList'
 import { OperationSetList } from 'components/OperationSetList'
 import { neoLayoutAtom } from 'store/pref'
+import {
+  selectedOperatorQueryAtom,
+  selectedOperatorsAtom,
+} from 'store/selectedOperators'
 
 import { authAtom } from '../store/auth'
 import { OperatorSelect } from './OperatorSelect'
 import { withSuspensable } from './Suspensable'
 
 export const Operations: ComponentType = withSuspensable(() => {
-  const [queryParams, setQueryParams] = useState<UseOperationsParams>({
+  const [queryParams, setQueryParams] = useState<
+    Omit<UseOperationsParams, 'operator'>
+  >({
     orderBy: 'hot',
   })
+  const [selectedOperators, setSelectedOperators] = useAtom(
+    selectedOperatorsAtom,
+  )
+  const selectedOperatorQuery = useAtomValue(selectedOperatorQueryAtom)
   const debouncedSetQueryParams = useMemo(
     () => debounce(setQueryParams, 500),
     [],
@@ -95,7 +105,7 @@ export const Operations: ComponentType = withSuspensable(() => {
             <div className="flex mr-4">
               <FormGroup
                 helperText={
-                  queryParams.operator?.length
+                  selectedOperators.length
                     ? '点击干员标签以标记为排除该干员'
                     : undefined
                 }
@@ -135,13 +145,8 @@ export const Operations: ComponentType = withSuspensable(() => {
                 />
                 <OperatorSelect
                   className="mt-2"
-                  operators={queryParams.operator?.split(',') || []}
-                  onChange={(operators) =>
-                    setQueryParams((old) => ({
-                      ...old,
-                      operator: operators.join(','),
-                    }))
-                  }
+                  operators={selectedOperatorQuery.split(',')}
+                  onChange={setSelectedOperators}
                 />
               </FormGroup>
             </div>
@@ -210,9 +215,12 @@ export const Operations: ComponentType = withSuspensable(() => {
       </Card>
 
       <div className="tabular-nums">
-        {listMode === 'operation' && <OperationList {...queryParams} />}
+        {listMode === 'operation' && (
+          <OperationList {...queryParams} operator={selectedOperatorQuery} />
+        )}
         {listMode === 'operationSet' && <OperationSetList {...queryParams} />}
       </div>
     </>
   )
 })
+Operations.displayName = 'Operations'

--- a/src/components/OperatorSelect.tsx
+++ b/src/components/OperatorSelect.tsx
@@ -14,7 +14,7 @@ interface OperatorSelectProps {
   onChange: (operators: string[]) => void
 }
 
-type OperatorInfo = typeof OPERATORS[number]
+type OperatorInfo = (typeof OPERATORS)[number]
 
 interface OperatorEntry {
   name: string
@@ -122,11 +122,12 @@ export const OperatorSelect: FC<OperatorSelectProps> = ({
         leftIcon: 'person',
         className: '!flex !p-0 !pl-[5px]',
         large: true,
-        tagProps(value, index) {
+        tagProps(_value, index) {
           const operator = operators[index]
 
           return {
             interactive: true,
+            className: operator.exclude ? 'line-through' : undefined,
             intent: operator?.exclude ? 'danger' : 'primary',
             onClick: () => setExclude(index, !operator?.exclude),
           }

--- a/src/store/selectedOperators.ts
+++ b/src/store/selectedOperators.ts
@@ -1,0 +1,17 @@
+import { atom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
+
+interface OperatorEntry {
+  name: string
+  exclude?: boolean
+}
+
+export const selectedOperatorsAtom = atomWithStorage(
+  'maa-copilot-selectedOperators',
+  [] as string[],
+)
+
+export const selectedOperatorQueryAtom = atom((get) => {
+  const operators = get(selectedOperatorsAtom)
+  return operators.join(',')
+})


### PR DESCRIPTION

根据 issue https://github.com/MaaAssistantArknights/maa-copilot-frontend/issues/305 持久化存储 `包含或者要排除的干员`, 顺便给排除的干员添加了删除线方便区分
<img width="583" alt="iTerm2 2024-06-13 19 28 19" src="https://github.com/MaaAssistantArknights/maa-copilot-frontend/assets/39239965/568e7058-8197-4a16-9ce6-87a1571a9f50">
