### PR TITLE
fix: stretch content's container in OperationCard

### DIFF
--- a/src/components/OperationCard.tsx
+++ b/src/components/OperationCard.tsx
@@ -23,9 +23,9 @@ export const NeoOperationCard = ({ operation }: { operation: Operation }) => {
     <Card
       interactive={true}
       elevation={Elevation.TWO}
-      className="relative flex flex-col gap-2"
+      className="relative"
     >
-      <ReLink search={{ op: operation.id }} className="block no-underline">
+      <ReLink search={{ op: operation.id }} className="no-underline h-full flex flex-col gap-2">
         <div className="flex">
           <Tooltip2
             content={operation.parsedContent.doc.title}


### PR DESCRIPTION
![image](https://github.com/MaaAssistantArknights/maa-copilot-frontend/assets/8043546/78316734-8e67-4169-8320-f5c935b9b63a)
