### PR TITLE
fix: the info of operator can not be edited properly.

### DIFF
--- a/src/components/editor/operator/EditorPerformer.tsx
+++ b/src/components/editor/operator/EditorPerformer.tsx
@@ -22,7 +22,7 @@ import { FC, useEffect, useState } from 'react'
 import { Control, UseFieldArrayMove, useFieldArray } from 'react-hook-form'
 import { SetRequired } from 'type-fest'
 
-import type { CopilotDocV1 } from 'models/copilot.schema'
+import { CopilotDocV1 } from 'models/copilot.schema'
 
 import { FactItem } from '../../FactItem'
 import { Droppable, Sortable } from '../../dnd'
@@ -289,7 +289,7 @@ export const EditorPerformer: FC<EditorPerformerProps> = ({ control }) => {
             addOperator()
           } else {
             updateOperator(
-              operators.findIndex(({ name }) => name === operator.name),
+              operators.findIndex(({ _id }) => _id === operator._id),
               operator,
             )
           }


### PR DESCRIPTION
更改干员查找更新方式，之前使用name字段导致在更改名字时会出现找不到更新目标的问题，修改为通过_id字段寻找需要更新的目标