### PR TITLE
Fix/issue 340

### DIFF
--- a/src/components/editor/action/EditorActionAdd.tsx
+++ b/src/components/editor/action/EditorActionAdd.tsx
@@ -102,9 +102,6 @@ export const EditorActionAdd = ({
 
   useEffect(() => {
     if (editingAction) {
-      if ('type' in editingAction) {
-        setValue('type', editingAction.type)
-      }
       // 修复切换type的时候，数据丢失的问题
       // 原因：因为切换type的时候会触发页面绘制，导致form和对应的item组件丢失绑定，
       // 当重置时没办法正常清空item组件内部的值。

--- a/src/components/editor/action/EditorActionAdd.tsx
+++ b/src/components/editor/action/EditorActionAdd.tsx
@@ -101,6 +101,13 @@ export const EditorActionAdd = ({
   )
 
   useEffect(() => {
+    if (editingAction?.type) {
+      setValue('type', editingAction.type)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editingAction?._id, setValue])
+
+  useEffect(() => {
     if (editingAction) {
       // 修复切换type的时候，数据丢失的问题
       // 原因：因为切换type的时候会触发页面绘制，导致form和对应的item组件丢失绑定，


### PR DESCRIPTION
优化了修改动作序列的逻辑，原先代码的在更改动作类型后会使用原有数据更新界面导致动作类型复原，故更新代码使其只有在不同动作序列切换时同步一次动作类型避免多次使用改变前的动作类型。