### PR TITLE
fix: lower the brightness of mumu ads in dark mode

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -74,12 +74,12 @@ const Ads =
     ? () => (
         // eslint-disable-next-line react/jsx-no-target-blank
         <a
-          className="block relative"
+          className="block relative dark:brightness-[85%]"
           href="https://gad.netease.com/gad/access?project_id=201005304&s=SppRGFTnJ1VxfSFEZWE6hY3pO4gn&code_type=1"
           target="_blank"
         >
           <img src="/ads_mumu.jpg" alt="MuMu模拟器" />
-          <div className="absolute bottom-2 right-2 border border-current rounded text-[10px] text-zinc-300 px-1">
+          <div className="absolute bottom-2 right-2 border border-current rounded text-[10px] text-zinc-300 px-1 ">
             广告
           </div>
         </a>


### PR DESCRIPTION
Dark mode下把mumu广告的亮度降低到85%