### PR TITLE
feat: 用户名校验添加前后不能包含空格校验

### DIFF
--- a/src/components/account/AuthFormShared.tsx
+++ b/src/components/account/AuthFormShared.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react-hook-form'
 
 import { FormField, FormFieldProps } from 'components/FormField'
-import { REGEX_EMAIL } from 'utils/regexes'
+import { REGEX_EMAIL, REGEX_USERNAME } from 'utils/regexes'
 
 export type RuleKeys = 'email' | 'password' | 'username' | 'registertoken'
 
@@ -25,6 +25,7 @@ export const rule: Record<RuleKeys, UseControllerProps['rules']> = {
     required: '用户名为必填项',
     minLength: { value: 4, message: '用户名长度不能小于 4 位' },
     maxLength: { value: 24, message: '用户名长度不能大于 24 位' },
+    pattern: { value: REGEX_USERNAME, message: '用户名前后不能包含空格' },
   },
   registertoken: {
     required: '邮箱验证码为必填项',

--- a/src/utils/regexes.ts
+++ b/src/utils/regexes.ts
@@ -2,3 +2,5 @@
 // let the server do the validation further and, if an email cannot be sent,
 // a sufficient error message is far better than tied-to-RFC validation on client side.
 export const REGEX_EMAIL = /^\S+@\S+\.\S+$/
+// 开头和结尾不能为空格，但是中间允许有空格
+export const REGEX_USERNAME = /^\S.{2,22}\S$/


### PR DESCRIPTION
由于后端未添加重名校验，现在按照用户搜索作业存在重名的问题，询问作业群的作者，前后空格的名称也不太必要，故添加该校验
后端添加了trim，如果后端先上线会导致前端展示的名称含有前后空格，但是后端存储的数据是trim后的
后端对应pr
https://github.com/MaaAssistantArknights/MaaBackendCenter/pull/194