### PR TITLE
perf: 优化内容渲染时间

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     <link rel="manifest" href="/site.webmanifest?v=1" />
     <link rel="mask-icon" href="/safari-pinned-tab.svg?v=1" color="#101010" />
     <link rel="shortcut icon" href="/favicon.ico?v=1" />
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" />
     <meta name="msapplication-TileColor" content="#101010" />
     <meta name="theme-color" content="#101010" />
   </head>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,36 @@ export default defineConfig(({ command, mode }) => {
     },
     build: {
       sourcemap: false,
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            maacopilot: ['maa-copilot-client'],
+            react: ["react", "react-dom", "react-router-dom"],
+            reactplugins: ["react-use", "react-rating", "react-markdown", "react-ga-neo", "react-hook-form"],
+            blueprint: ["@blueprintjs/core"],
+            blueprintaddon: ["@blueprintjs/select", "@blueprintjs/popover2"],
+            sentry: ["@sentry/react", "@sentry/tracing"],
+            dnd: ["@dnd-kit/core", "@dnd-kit/sortable", "@dnd-kit/utilities"],
+            jotai: ["jotai", "jotai-immer", "jotai-devtools", "immer"],
+            remark: ["remark-gfm", "remark-breaks"],
+            iconify: ["@iconify/react"],
+            ajv: ["ajv", "ajv-i18n"],
+            linkify: ['linkify-react', 'linkifyjs'],
+            utils: [
+              "lodash-es",
+              "clsx",
+              "dayjs",
+              "fuse.js",
+              "mitt",
+              "swr",
+              "swr/infinite",
+              "camelcase-keys",
+              "snakecase-keys",
+              "zod"
+            ],
+          },
+        }
+      }
     },
   }
 })


### PR DESCRIPTION
1. 添加 preconnect 加快未来从给定源加载的速度。

3. 调整 rollupOptions 将依赖分离chunk以加快渲染速度，同时更加适合CDN缓存（即常用依赖未变更的情况下其chunk不会发生变化）

## 测试环境

Chrome `140.0.7339.185`
Lighthouse
Yarn `1.22.19`

## 修改前
<img width="608" height="65" alt="1" src="https://github.com/user-attachments/assets/d7febe55-7349-4179-beb1-d40307e78241" />

## 修改后
<img width="679" height="80" alt="2" src="https://github.com/user-attachments/assets/3d1484c5-0edc-4932-ad4f-6e30fea98665" />

