### PR TITLE
fix: 作业集弹窗关闭优化，使嵌套抽屉能正确顺序关闭

### DIFF
--- a/src/components/drawer/OperationDrawer.tsx
+++ b/src/components/drawer/OperationDrawer.tsx
@@ -35,12 +35,24 @@ export function OperationDrawer() {
     })
   }
 
+  const handleOuterBackdropClick = (e?: SyntheticEvent) => {
+    if (e?.nativeEvent instanceof MouseEvent && e.nativeEvent.button !== 0) {
+      return
+    }
+
+    if (operationId) {
+      closeOperation(e)
+    } else {
+      closeOperationSet(e)
+    }
+  }
+
   if (operationSetId) {
     return (
       <Drawer
         size={DrawerSize.LARGE}
         isOpen={!!operationSetId}
-        onClose={closeOperationSet}
+        onClose={handleOuterBackdropClick}
       >
         {operationSetId && (
           <OperationSetViewer


### PR DESCRIPTION
先打开作业集弹窗，再打开对应作业弹窗，如果点最外层灰色背景会直接关闭外层，导致作业集弹窗丢失；修改作业集弹窗关闭逻辑，如果在作业弹窗打开时点到作业集弹窗，关闭作业弹窗。