### PR TITLE
chore: 升级 Blueprint v4 → v6，迁移到 PopoverNext (Floating UI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,8 @@ jobs:
       # oxlint, so the remaining warnings stay visible without blocking.
       - name: Lint
         run: pnpm lint
+
+      # Build uses build:fast (vite build only); typecheck above already ran
+      # generate:i18n and tsc --noEmit, so we skip the redundant work here.
+      - name: Build
+        run: pnpm build:fast

--- a/package.json
+++ b/package.json
@@ -21,10 +21,9 @@
     "scripts:update-prof-icons": "pnpm install && tsx scripts/update-prof-icons.ts"
   },
   "dependencies": {
-    "@blueprintjs/core": "^4.15.1",
-    "@blueprintjs/icons": "^4.15.1",
-    "@blueprintjs/popover2": "^1.12.1",
-    "@blueprintjs/select": "^4.8.18",
+    "@blueprintjs/core": "^6.16.0",
+    "@blueprintjs/icons": "^6.11.0",
+    "@blueprintjs/select": "^6.3.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
@@ -78,7 +77,6 @@
     "@types/react-dom": "^18.0.0",
     "@vitejs/plugin-react": "^6.0.3",
     "autoprefixer": "^10.4.7",
-    "tsx": "^4.0.0",
     "less": "^4.1.2",
     "oxfmt": "^0.56.0",
     "oxlint": "^1.71.0",
@@ -87,7 +85,13 @@
     "sharp": "^0.34.2",
     "simplebig": "^0.0.3",
     "tailwindcss": "^3.1.4",
+    "tsx": "^4.0.0",
     "typescript": "7.0.1-rc",
     "vite": "^8.1.0"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@popperjs/core@2.11.8": "patches/@popperjs__core@2.11.8.patch"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -88,10 +88,5 @@
     "tsx": "^4.0.0",
     "typescript": "7.0.1-rc",
     "vite": "^8.1.0"
-  },
-  "pnpm": {
-    "patchedDependencies": {
-      "@popperjs/core@2.11.8": "patches/@popperjs__core@2.11.8.patch"
-    }
   }
 }

--- a/patches/@popperjs__core@2.11.8.patch
+++ b/patches/@popperjs__core@2.11.8.patch
@@ -1,0 +1,19 @@
+diff --git a/lib/index.js b/lib/index.js
+index c0c8b52db9f339e17fbf68c8e2aa36862776fe0a..5fb20e8ef294fa019322219c685d8193993dc419 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -1,6 +1,14 @@
++import * as enums from "./enums.js";
++
+ export * from "./enums.js";
+ export * from "./modifiers/index.js"; // eslint-disable-next-line import/no-unused-modules
+ 
++// Rolldown(Vite 8 的打包器）会把通过 `export *` 链路重导出、且带有 `/*#__PURE__*/`
++// 注解的 `placements` 当作纯重导出在 link 阶段提前剔除，导致下游
++// `@blueprintjs/core` 的 `export { placements as PopperPlacements }` 解析失败
++// （rolldown/rolldown#9122）。这里用本地绑定显式重导出，规避该优化。
++export const placements = enums.placements;
++
+ export { popperGenerator, detectOverflow, createPopper as createPopperBase } from "./createPopper.js"; // eslint-disable-next-line import/no-unused-modules
+ 
+ export { createPopper } from "./popper.js"; // eslint-disable-next-line import/no-unused-modules

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,22 +9,24 @@ overrides:
   electron-to-chromium: 1.5.364
   postcss: 8.5.15
 
+patchedDependencies:
+  '@popperjs/core@2.11.8':
+    hash: f66c4ef111aede520720d05ca6781461ccc156259f504bfc97a5e88577b7c5ff
+    path: patches/@popperjs__core@2.11.8.patch
+
 importers:
 
   .:
     dependencies:
       '@blueprintjs/core':
-        specifier: ^4.15.1
-        version: 4.15.1(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+        specifier: ^6.16.0
+        version: 6.16.0(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
       '@blueprintjs/icons':
-        specifier: ^4.15.1
-        version: 4.16.0
-      '@blueprintjs/popover2':
-        specifier: ^1.12.1
-        version: 1.14.11(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+        specifier: ^6.11.0
+        version: 6.11.0(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
       '@blueprintjs/select':
-        specifier: ^4.8.18
-        version: 4.8.18(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+        specifier: ^6.3.0
+        version: 6.3.0(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
@@ -290,53 +292,36 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@blueprintjs/colors@4.1.14':
-    resolution: {integrity: sha512-MT++a/OSGui8tMpo5dEogrTV/PJCsHuhXTmdsGQtzivlLwBAp1XKe/Np4vaX6seJqRgR0oyXgS9kVvomCl463Q==}
+  '@blueprintjs/colors@5.1.16':
+    resolution: {integrity: sha512-P9uX0Aj2TP9+6aUcori1iPl4snxM/Vgq0LZbhUl1l5bHTgNxxwm/0+IoS/SlQg93HBRl8KTAM1evEqtPbwV10A==}
 
-  '@blueprintjs/colors@4.2.1':
-    resolution: {integrity: sha512-Cx7J2YnUuxn+fi+y5XtXnBB7+cFHN4xBrRkaAetp78i3VTCXjUk+d1omrOr8TqbRucUXTdrhbZOUHpzRLFcJpQ==}
-
-  '@blueprintjs/core@4.15.1':
-    resolution: {integrity: sha512-EAg9lFsHTZeXyTtX5YI2lHb2AxoUT1fLFf8wT+cxvMoCrU+JUcxDZ616ewTeZX6CC3BpgxW3wqJ56SYkKRBp4g==}
+  '@blueprintjs/core@6.16.0':
+    resolution: {integrity: sha512-xVamwaXDsWxekKmfgx1RuS79V8vqAEn8rYdZLmTLbObZwrZ4Vj7sy/S0Qri5wMid4hVYncSExlXcurWvHoRgrA==}
     hasBin: true
     peerDependencies:
-      '@types/react': ^16.14.32 || 17 || 18
-      react: ^16.8 || 17 || 18
-      react-dom: ^16.8 || 17 || 18
+      '@types/react': 18 || 19
+      react: 18 || 19
+      react-dom: 18 || 19
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@blueprintjs/core@4.20.2':
-    resolution: {integrity: sha512-5v4Nr0jozfAjiOkjY4zvt1XSpt4ldnrSaxtwo506S2cxJYfwFeMTmDshXNPFcc8L1fjZMxi0IWI2WABXzZXS6w==}
-    hasBin: true
+  '@blueprintjs/icons@6.11.0':
+    resolution: {integrity: sha512-LKNsI2ukS+Q/cRlghzdQcEVHu8tdTw+aXtgjSqecjxOcnjy+mItcMR5DCdwTHMMejEtrFNTwAlrvsz9MFYc1iA==}
     peerDependencies:
-      '@types/react': ^16.14.32 || 17 || 18
-      react: ^16.8 || 17 || 18
-      react-dom: ^16.8 || 17 || 18
+      '@types/react': 18 || 19
+      react: 18 || 19
+      react-dom: 18 || 19
     peerDependenciesMeta:
       '@types/react':
         optional: true
 
-  '@blueprintjs/icons@4.16.0':
-    resolution: {integrity: sha512-cyfgjUZcZCtQrXWUV8FwqYTFEzduV4a0N7yhOU38jY+cBRCLu/sDrD0Osvfk4DGRvNe4YjY7pohVLFSxpg68Uw==}
-
-  '@blueprintjs/popover2@1.14.11':
-    resolution: {integrity: sha512-5XAjeb2mlWjYXC0pqrNDLzHSsX85Zaiv8jixxUN9abarMUUFKGATgGF8MRsWTLAW94Gli6CB1lzVkrYkRHHf6Q==}
+  '@blueprintjs/select@6.3.0':
+    resolution: {integrity: sha512-m+tQ6PIG/qWfGUwx2DFZs7nKZfMwx4OKPT4yO5aVe9JCqVkJGs+ZdEfjFO4zf6PF6lD0e9Yxyis497YJh1lawA==}
     peerDependencies:
-      '@types/react': ^16.14.32 || 17 || 18
-      react: ^16.8 || 17 || 18
-      react-dom: ^16.8 || 17 || 18
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@blueprintjs/select@4.8.18':
-    resolution: {integrity: sha512-ogFz7HRF7npUew7+A9ZQDzeVxxSa6P8+WtWHqtOZ9OQEqykDvlFz06XW6EwxTWbpiH5+5RWXTQuxhaaYNAWwTQ==}
-    peerDependencies:
-      '@types/react': ^16.14.32 || 17 || 18
-      react: ^16.8 || 17 || 18
-      react-dom: ^16.8 || 17 || 18
+      '@types/react': 18 || 19
+      react: 18 || 19
+      react-dom: 18 || 19
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -609,6 +594,12 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
+  '@floating-ui/react@0.27.19':
+    resolution: {integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
@@ -617,12 +608,6 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
       react-dom: ^16.8.0 || ^17 || ^18 || ^19
-
-  '@hypnosphi/create-react-context@0.3.1':
-    resolution: {integrity: sha512-V1klUed202XahrWJLLOT3EXNeCpFHCcJntdFGI15ntCwau+jfT386w7OFTMaCqOgXUH1fa0w/I1oZs+i/Rfr0A==}
-    peerDependencies:
-      prop-types: ^15.0.0
-      react: '>=0.14.0'
 
   '@iconify/icons-simple-icons@1.2.74':
     resolution: {integrity: sha512-bsmbvwO8hauz49z740CYg70IDevOgshUoq4q1IKt6NnElnn+N2F6AseO3Uti82yUU4OHyQqkWjjUwoPTazlNnA==}
@@ -661,85 +646,72 @@ packages:
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.2':
     resolution: {integrity: sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.2':
     resolution: {integrity: sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.2':
     resolution: {integrity: sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.2':
     resolution: {integrity: sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.2':
     resolution: {integrity: sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.2':
     resolution: {integrity: sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.2':
     resolution: {integrity: sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==}
@@ -818,9 +790,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@juggle/resize-observer@3.4.0':
-    resolution: {integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==}
-
   '@mantine/code-highlight@7.16.2':
     resolution: {integrity: sha512-8qgmJehetGMOL8uGXZCYQUCQPEW+D/+dtO1Z7ZrNb+E0YGdnLIXhsWzBSNvJWZlBVfwDZ+V1w09FHf3y2LAZjw==}
     peerDependencies:
@@ -895,28 +864,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@node-rs/jieba-linux-arm64-musl@1.10.4':
     resolution: {integrity: sha512-Y/tiJ1+HeS5nnmLbZOE+66LbsPOHZ/PUckAYVeLlQfpygLEpLYdlh0aPpS5uiaWMjAXYZYdFkpZHhxDmSLpwpw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@node-rs/jieba-linux-x64-gnu@1.10.4':
     resolution: {integrity: sha512-WZO8ykRJpWGE9MHuZpy1lu3nJluPoeB+fIJJn5CWZ9YTVhNDWoCF4i/7nxz1ntulINYGQ8VVuCU9LD86Mek97g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@node-rs/jieba-linux-x64-musl@1.10.4':
     resolution: {integrity: sha512-uBBD4S1rGKcgCyAk6VCKatEVQb6EDD5I40v/DxODi5CuZVCANi9m5oee/MQbAoaX7RydA2f0OSCE9/tcwXEwUg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@node-rs/jieba-wasm32-wasi@1.10.4':
     resolution: {integrity: sha512-Y2umiKHjuIJy0uulNDz9SDYHdfq5Hmy7jY5nORO99B4pySKkcrMjpeVrmWXJLIsEKLJwcCXHxz8tjwU5/uhz0A==}
@@ -1007,56 +972,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.56.0':
     resolution: {integrity: sha512-UekqOjGkV4/MkqreCV9SPIB2jlR3/HbXrmhV1rVXJZ9wfDXMyCMriLtq3tHqLY4PkbVWNtfcm1kMojJ26KLSJw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.56.0':
     resolution: {integrity: sha512-XSzveSpeZMD5XJpew5lRFVtNnT04xd3rJxENXmk7wkZzN9oWzv2aFJyoNDhOtoz69BYaS/fg4SYl+CfEZRpB0Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.56.0':
     resolution: {integrity: sha512-EkQ0nJa7k7HDDIVuPF7WY+k4k+bzdclLYtyIXNt7/OqVghfNiMym6YGppFBgx1XRIHW6QylxBz5OogumPjPJbQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.56.0':
     resolution: {integrity: sha512-dyjAGW8jKRge0ik6U/dgvQG0nVpA3iBlRskQTz5qJLvQWIrySxX5jpqzPetLBNIIZ231KA82fDdi1nLTk8ENCw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.56.0':
     resolution: {integrity: sha512-60ZGH3LtfqlW8X6vcLdSFY4lvCQYINurttYBKaALnHCDVAUCYJ1LsUgS6p1XOzVlzEDx3yNUZvDF1Lvt59zoZw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.56.0':
     resolution: {integrity: sha512-u1suj1tgJHK4ZqB7buCtdbNef2n8+d0lXTPJwLHNmtyK6p+DTpsaoDvmqhQrA56fgKYv4LuRxNtL8YooebKOew==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.56.0':
     resolution: {integrity: sha512-aYGLvlQHt80y+qKEtfJY/Nm27G0125Lv+qyh9SJ4Cjc6lXnXjD+ndfhqQnbV24POpMi7rNRi0jvx/0d70FRpCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.56.0':
     resolution: {integrity: sha512-H/re/gO+7ysVc+kywHNuzY3C33EN9sQcZhg0kp1ZwOZl7y998ZE5mhnBiuGR/nYI0pqLL5xQfrHVUOJ/cIJsCA==}
@@ -1159,56 +1116,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.71.0':
     resolution: {integrity: sha512-fJZrs5sDZtTaPIOiemRQQmo82Ezy+vOGXemPc4Ok7iVVsYsFa7SlW6Z5XN819VfsqBHRm3NJ3rTdnR8+bJYJdQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.71.0':
     resolution: {integrity: sha512-cwl7VKGERIy9p+G+AvZdfy/06q0aHXaTt/mMRReC751iuNYJgqKjB7NydXSS30nBT9vtr2tunciOtrR4fD6FUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.71.0':
     resolution: {integrity: sha512-eZ8ieVXvzGi8jr7+ybQGPK2STw3mldfxZlgA2738iflfB/rzA69sE6m5rDRpQaxC7dpm745Enlh1Tod0QAk9Gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.71.0':
     resolution: {integrity: sha512-puMDbQYe6+NXwfMusojoA7CXGn2b3utukmd23PQqc1E3XhVCwyZ+FueSMzDYeNgDV2dUfIVXAAKZBcFDeCL6sA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.71.0':
     resolution: {integrity: sha512-4NJLxBs1ujISCt3L/1FcywLs73PWtJuw+piD6feK2V6h6OS6P7xu9/sWt1DTRLibe6QCzmfZzmM/2HPORoV/Lg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.71.0':
     resolution: {integrity: sha512-cFDaiR8L3430qp88tfZnvFlt3KotFhR/DlbIL0nHOMMYiG/9Wy4l+6f7t8G8pTa9bd8Lt8+M0y/qjRQ/xcB74g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.71.0':
     resolution: {integrity: sha512-orfixdt76KlpNly9z0PkWBBNfwjKz+JFVLP/7wnVchlKNU9Dpt9InU/ZggeSej6fC7qwHmHNOGlhLnQXcYoGuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.71.0':
     resolution: {integrity: sha512-9emQu2lAp6yhPB3XuI+++vR+l/o6JR1X+EpxwcumPdQXBWXEPAsquPGL7l158EqU8SebQMXTUa/S5zN98juyHw==}
@@ -1417,42 +1366,36 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.1.3':
     resolution: {integrity: sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.3':
     resolution: {integrity: sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.3':
     resolution: {integrity: sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.3':
     resolution: {integrity: sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.1.3':
     resolution: {integrity: sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.1.3':
     resolution: {integrity: sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==}
@@ -1526,9 +1469,6 @@ packages:
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
-
-  '@types/dom4@2.0.4':
-    resolution: {integrity: sha512-PD+wqNhrjWFjAlSVd18jvChZvOXB2SOwAILBmuYev5zswBats5qmzs/QFoooLKd2omj9BT05a8MeSeRmXLGY+Q==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -1892,18 +1832,6 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
-  call-bind-apply-helpers@1.0.2:
-    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
-    engines: {node: '>= 0.4'}
-
-  call-bind@1.0.9:
-    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
-    engines: {node: '>= 0.4'}
-
-  call-bound@1.0.4:
-    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
-    engines: {node: '>= 0.4'}
-
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -2124,18 +2052,6 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
-  deep-equal@1.1.2:
-    resolution: {integrity: sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==}
-    engines: {node: '>= 0.4'}
-
-  define-data-property@1.1.4:
-    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
-    engines: {node: '>= 0.4'}
-
-  define-properties@1.2.1:
-    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
-    engines: {node: '>= 0.4'}
-
   delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
@@ -2178,15 +2094,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dom4@2.1.6:
-    resolution: {integrity: sha512-JkCVGnN4ofKGbjf5Uvc8mmxaATIErKQKSgACdBXpsQ3fY6DlIpAyWfiBSrGkttATssbDCp3psiAKWXk5gmjycA==}
-
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
-
-  dunder-proto@1.0.1:
-    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
-    engines: {node: '>= 0.4'}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -2215,16 +2124,8 @@ packages:
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
-  es-define-property@1.0.1:
-    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
-    engines: {node: '>= 0.4'}
-
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
-    engines: {node: '>= 0.4'}
-
-  es-object-atoms@1.1.2:
-    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.28.0:
@@ -2336,9 +2237,6 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  functions-have-names@1.2.3:
-    resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
-
   fuse.js@6.6.2:
     resolution: {integrity: sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==}
     engines: {node: '>=10'}
@@ -2355,17 +2253,9 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-intrinsic@1.3.0:
-    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
-    engines: {node: '>= 0.4'}
-
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
-
-  get-proto@1.0.1:
-    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
-    engines: {node: '>= 0.4'}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2379,30 +2269,12 @@ packages:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  gopd@1.2.0:
-    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
-    engines: {node: '>= 0.4'}
-
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  gud@1.0.0:
-    resolution: {integrity: sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-
-  has-property-descriptors@1.0.2:
-    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
-
-  has-symbols@1.1.0:
-    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
 
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
@@ -2513,10 +2385,6 @@ packages:
   is-alphanumerical@2.0.1:
     resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
-  is-arguments@1.2.0:
-    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
-    engines: {node: '>= 0.4'}
-
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
@@ -2533,10 +2401,6 @@ packages:
 
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
-    engines: {node: '>= 0.4'}
-
-  is-date-object@1.1.0:
-    resolution: {integrity: sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==}
     engines: {node: '>= 0.4'}
 
   is-decimal@2.0.1:
@@ -2573,10 +2437,6 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
-
-  is-regex@1.2.1:
-    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
-    engines: {node: '>= 0.4'}
 
   is-what@4.1.16:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
@@ -2682,6 +2542,7 @@ packages:
     resolution: {integrity: sha512-Quz3MvAwHxVYNXsOByL7xI5EB2WYOeFswqaHIA3qOK3isRWTxiplBEocmmru6XmxDB2L7jDNYtYA4FyimoAFEw==}
     engines: {node: '>=8.17.0'}
     hasBin: true
+    bundledDependencies: []
 
   keypress@0.1.0:
     resolution: {integrity: sha512-x0yf9PL/nx9Nw9oLL8ZVErFAk85/lslwEP7Vz7s5SI1ODXZIgit3C5qyWjw4DxOuO/3Hb4866SQh28a1V1d+WA==}
@@ -2736,28 +2597,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2822,7 +2679,7 @@ packages:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   maa-copilot-client@https://codeload.github.com/ZOOT-Plus/zoot-plus-client-ts/tar.gz/e947beff7e028eea0b179771929f3b86a339625b:
-    resolution: {gitHosted: true, integrity: sha512-lNGhFaWlD+0OIudmyp3pPYsPgdJ95T95S2Wy//Abv5pv+D5kUhZw2Z15n3zDsFWf/KkarGQz0K2E587bap2pSQ==, tarball: https://codeload.github.com/ZOOT-Plus/zoot-plus-client-ts/tar.gz/e947beff7e028eea0b179771929f3b86a339625b}
+    resolution: {integrity: sha512-lNGhFaWlD+0OIudmyp3pPYsPgdJ95T95S2Wy//Abv5pv+D5kUhZw2Z15n3zDsFWf/KkarGQz0K2E587bap2pSQ==, tarball: https://codeload.github.com/ZOOT-Plus/zoot-plus-client-ts/tar.gz/e947beff7e028eea0b179771929f3b86a339625b}
     version: 0.1.0-SNAPSHOT.999.sha.d286f0d
 
   make-dir@2.1.0:
@@ -2845,10 +2702,6 @@ packages:
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
-
-  math-intrinsics@1.1.0:
-    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
-    engines: {node: '>= 0.4'}
 
   mdast-util-find-and-replace@2.2.2:
     resolution: {integrity: sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==}
@@ -3186,14 +3039,6 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
-  object-is@1.1.6:
-    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
-    engines: {node: '>= 0.4'}
-
-  object-keys@1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
-    engines: {node: '>= 0.4'}
-
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -3309,10 +3154,6 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
-
-  popper.js@1.16.1:
-    resolution: {integrity: sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==}
-    deprecated: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -3490,11 +3331,6 @@ packages:
       react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react-popper@1.3.11:
-    resolution: {integrity: sha512-VSA/bS+pSndSF2fiasHK/PTEEAyOpX60+H5EPAjoArr8JGm+oihu4UbrqcEBpQibJxBVCpYyjAX7abJ+7DoYVg==}
-    peerDependencies:
-      react: 0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0
-
   react-popper@2.3.0:
     resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
     peerDependencies:
@@ -3647,10 +3483,6 @@ packages:
   regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
-  regexp.prototype.flags@1.5.4:
-    resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
-    engines: {node: '>= 0.4'}
-
   remark-breaks@3.0.3:
     resolution: {integrity: sha512-C7VkvcUp1TPUc2eAYzsPdaUh8Xj4FSbQnYA5A9f80diApLZscTDeG7efiWP65W8hV2sEy3JuGVU0i6qr5D8Hug==}
 
@@ -3774,14 +3606,6 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-
-  set-function-length@1.2.2:
-    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
-    engines: {node: '>= 0.4'}
-
-  set-function-name@2.0.2:
-    resolution: {integrity: sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==}
-    engines: {node: '>= 0.4'}
 
   set-harmonic-interval@1.0.1:
     resolution: {integrity: sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==}
@@ -4008,12 +3832,6 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
-  tslib@2.3.1:
-    resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
-
-  tslib@2.5.3:
-    resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
-
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
@@ -4040,9 +3858,6 @@ packages:
   type-fest@4.40.1:
     resolution: {integrity: sha512-9YvLNnORDpI+vghLU/Nf+zSv0kL47KbVJ1o3sKgoTefl6i+zebxbiDQWoe/oWWqPhIgQdRZRT1KA9sCPL810SA==}
     engines: {node: '>=16'}
-
-  typed-styles@0.0.7:
-    resolution: {integrity: sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q==}
 
   typescript@7.0.1-rc:
     resolution: {integrity: sha512-drEP77wK7CCDlPfXZH4e008UUQOsw1DFmHmZOZjuNA+yoDLLnSNMZRXi90NbV/1LVo7SbNLq1bs3jjvk49TEqQ==}
@@ -4434,76 +4249,45 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@blueprintjs/colors@4.1.14': {}
-
-  '@blueprintjs/colors@4.2.1':
+  '@blueprintjs/colors@5.1.16':
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
 
-  '@blueprintjs/core@4.15.1(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
+  '@blueprintjs/core@6.16.0(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
     dependencies:
-      '@blueprintjs/colors': 4.1.14
-      '@blueprintjs/icons': 4.16.0
-      '@juggle/resize-observer': 3.4.0
-      '@types/dom4': 2.0.4
+      '@blueprintjs/colors': 5.1.16
+      '@blueprintjs/icons': 6.11.0(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+      '@floating-ui/react': 0.27.19(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+      '@popperjs/core': 2.11.8(patch_hash=f66c4ef111aede520720d05ca6781461ccc156259f504bfc97a5e88577b7c5ff)
       classnames: 2.5.1
-      dom4: 2.1.6
       normalize.css: 8.0.1
-      popper.js: 1.16.1
       react: 18.0.0
       react-dom: 18.0.0(react@18.0.0)
-      react-popper: 1.3.11(react@18.0.0)
+      react-popper: 2.3.0(@popperjs/core@2.11.8(patch_hash=f66c4ef111aede520720d05ca6781461ccc156259f504bfc97a5e88577b7c5ff))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
       react-transition-group: 4.4.5(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
-      tslib: 2.3.1
+      tslib: 2.6.2
     optionalDependencies:
       '@types/react': 18.3.29
 
-  '@blueprintjs/core@4.20.2(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
-    dependencies:
-      '@blueprintjs/colors': 4.2.1
-      '@blueprintjs/icons': 4.16.0
-      '@juggle/resize-observer': 3.4.0
-      '@types/dom4': 2.0.4
-      classnames: 2.5.1
-      dom4: 2.1.6
-      normalize.css: 8.0.1
-      popper.js: 1.16.1
-      react: 18.0.0
-      react-dom: 18.0.0(react@18.0.0)
-      react-popper: 1.3.11(react@18.0.0)
-      react-transition-group: 4.4.5(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
-      tslib: 2.5.3
-    optionalDependencies:
-      '@types/react': 18.3.29
-
-  '@blueprintjs/icons@4.16.0':
+  '@blueprintjs/icons@6.11.0(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
     dependencies:
       change-case: 4.1.2
       classnames: 2.5.1
-      tslib: 2.5.3
-
-  '@blueprintjs/popover2@1.14.11(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
-    dependencies:
-      '@blueprintjs/core': 4.20.2(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
-      '@juggle/resize-observer': 3.4.0
-      '@popperjs/core': 2.11.8
-      classnames: 2.5.1
-      dom4: 2.1.6
       react: 18.0.0
       react-dom: 18.0.0(react@18.0.0)
-      react-popper: 2.3.0(@popperjs/core@2.11.8)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
-      tslib: 2.5.3
+      tslib: 2.6.2
     optionalDependencies:
       '@types/react': 18.3.29
 
-  '@blueprintjs/select@4.8.18(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
+  '@blueprintjs/select@6.3.0(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
     dependencies:
-      '@blueprintjs/core': 4.15.1(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
-      '@blueprintjs/popover2': 1.14.11(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+      '@blueprintjs/colors': 5.1.16
+      '@blueprintjs/core': 6.16.0(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+      '@blueprintjs/icons': 6.11.0(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
       classnames: 2.5.1
       react: 18.0.0
       react-dom: 18.0.0(react@18.0.0)
-      tslib: 2.3.1
+      tslib: 2.6.2
     optionalDependencies:
       '@types/react': 18.3.29
 
@@ -4748,6 +4532,14 @@ snapshots:
       react-dom: 18.0.0(react@18.0.0)
       tabbable: 6.4.0
 
+  '@floating-ui/react@0.27.19(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
+      '@floating-ui/utils': 0.2.11
+      react: 18.0.0
+      react-dom: 18.0.0(react@18.0.0)
+      tabbable: 6.4.0
+
   '@floating-ui/utils@0.2.11': {}
 
   '@hookform/devtools@4.4.0(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
@@ -4765,13 +4557,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
-
-  '@hypnosphi/create-react-context@0.3.1(prop-types@15.8.1)(react@18.0.0)':
-    dependencies:
-      gud: 1.0.0
-      prop-types: 15.8.1
-      react: 18.0.0
-      warning: 4.0.3
 
   '@iconify/icons-simple-icons@1.2.74':
     dependencies:
@@ -4923,8 +4708,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.4.14
-
-  '@juggle/resize-observer@3.4.0': {}
 
   '@mantine/code-highlight@7.16.2(@mantine/core@7.16.2(@mantine/hooks@7.16.2(react@18.0.0))(@types/react@18.3.29)(react-dom@18.0.0(react@18.0.0))(react@18.0.0))(@mantine/hooks@7.16.2(react@18.0.0))(react-dom@18.0.0(react@18.0.0))(react@18.0.0)':
     dependencies:
@@ -5191,7 +4974,7 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.71.0':
     optional: true
 
-  '@popperjs/core@2.11.8': {}
+  '@popperjs/core@2.11.8(patch_hash=f66c4ef111aede520720d05ca6781461ccc156259f504bfc97a5e88577b7c5ff)': {}
 
   '@react-native/assets-registry@0.85.3': {}
 
@@ -5477,8 +5260,6 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
-
-  '@types/dom4@2.0.4': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -5778,23 +5559,6 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  call-bind-apply-helpers@1.0.2:
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-
-  call-bind@1.0.9:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      get-intrinsic: 1.3.0
-      set-function-length: 1.2.2
-
-  call-bound@1.0.4:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      get-intrinsic: 1.3.0
-
   callsites@3.1.0: {}
 
   camel-case@4.1.2:
@@ -6038,27 +5802,6 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  deep-equal@1.1.2:
-    dependencies:
-      is-arguments: 1.2.0
-      is-date-object: 1.1.0
-      is-regex: 1.2.1
-      object-is: 1.1.6
-      object-keys: 1.1.1
-      regexp.prototype.flags: 1.5.4
-
-  define-data-property@1.1.4:
-    dependencies:
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      gopd: 1.2.0
-
-  define-properties@1.2.1:
-    dependencies:
-      define-data-property: 1.1.4
-      has-property-descriptors: 1.0.2
-      object-keys: 1.1.1
-
   delegates@1.0.0:
     optional: true
 
@@ -6090,18 +5833,10 @@ snapshots:
       '@babel/runtime': 7.29.7
       csstype: 3.2.3
 
-  dom4@2.1.6: {}
-
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
-
-  dunder-proto@1.0.1:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-errors: 1.3.0
-      gopd: 1.2.0
 
   ee-first@1.1.1: {}
 
@@ -6126,13 +5861,7 @@ snapshots:
     dependencies:
       stackframe: 1.3.4
 
-  es-define-property@1.0.1: {}
-
   es-errors@1.3.0: {}
-
-  es-object-atoms@1.1.2:
-    dependencies:
-      es-errors: 1.3.0
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -6248,8 +5977,6 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  functions-have-names@1.2.3: {}
-
   fuse.js@6.6.2: {}
 
   gauge@2.7.4:
@@ -6268,25 +5995,7 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-intrinsic@1.3.0:
-    dependencies:
-      call-bind-apply-helpers: 1.0.2
-      es-define-property: 1.0.1
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.2
-      function-bind: 1.1.2
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      has-symbols: 1.1.0
-      hasown: 2.0.4
-      math-intrinsics: 1.1.0
-
   get-nonce@1.0.1: {}
-
-  get-proto@1.0.1:
-    dependencies:
-      dunder-proto: 1.0.1
-      es-object-atoms: 1.1.2
 
   glob-parent@5.1.2:
     dependencies:
@@ -6306,23 +6015,9 @@ snapshots:
       path-is-absolute: 1.0.1
     optional: true
 
-  gopd@1.2.0: {}
-
   graceful-fs@4.2.11: {}
 
-  gud@1.0.0: {}
-
   has-flag@4.0.0: {}
-
-  has-property-descriptors@1.0.2:
-    dependencies:
-      es-define-property: 1.0.1
-
-  has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
 
   has-unicode@2.0.1:
     optional: true
@@ -6461,11 +6156,6 @@ snapshots:
       is-alphabetical: 2.0.1
       is-decimal: 2.0.1
 
-  is-arguments@1.2.0:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
-
   is-arrayish@0.2.1: {}
 
   is-arrayish@0.3.4: {}
@@ -6479,11 +6169,6 @@ snapshots:
   is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.4
-
-  is-date-object@1.1.0:
-    dependencies:
-      call-bound: 1.0.4
-      has-tostringtag: 1.0.2
 
   is-decimal@2.0.1: {}
 
@@ -6507,13 +6192,6 @@ snapshots:
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
-
-  is-regex@1.2.1:
-    dependencies:
-      call-bound: 1.0.4
-      gopd: 1.2.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.4
 
   is-what@4.1.16: {}
 
@@ -6750,8 +6428,6 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marky@1.3.0: {}
-
-  math-intrinsics@1.1.0: {}
 
   mdast-util-find-and-replace@2.2.2:
     dependencies:
@@ -7414,13 +7090,6 @@ snapshots:
 
   object-hash@3.0.0: {}
 
-  object-is@1.1.6:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-
-  object-keys@1.1.1: {}
-
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -7567,8 +7236,6 @@ snapshots:
       - supports-color
 
   pirates@4.0.7: {}
-
-  popper.js@1.16.1: {}
 
   postcss-import@15.1.0(postcss@8.5.15):
     dependencies:
@@ -7793,20 +7460,9 @@ snapshots:
       react: 18.0.0
       react-dom: 18.0.0(react@18.0.0)
 
-  react-popper@1.3.11(react@18.0.0):
+  react-popper@2.3.0(@popperjs/core@2.11.8(patch_hash=f66c4ef111aede520720d05ca6781461ccc156259f504bfc97a5e88577b7c5ff))(react-dom@18.0.0(react@18.0.0))(react@18.0.0):
     dependencies:
-      '@babel/runtime': 7.29.7
-      '@hypnosphi/create-react-context': 0.3.1(prop-types@15.8.1)(react@18.0.0)
-      deep-equal: 1.1.2
-      popper.js: 1.16.1
-      prop-types: 15.8.1
-      react: 18.0.0
-      typed-styles: 0.0.7
-      warning: 4.0.3
-
-  react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.0.0(react@18.0.0))(react@18.0.0):
-    dependencies:
-      '@popperjs/core': 2.11.8
+      '@popperjs/core': 2.11.8(patch_hash=f66c4ef111aede520720d05ca6781461ccc156259f504bfc97a5e88577b7c5ff)
       react: 18.0.0
       react-dom: 18.0.0(react@18.0.0)
       react-fast-compare: 3.2.2
@@ -7994,15 +7650,6 @@ snapshots:
 
   regenerator-runtime@0.13.11: {}
 
-  regexp.prototype.flags@1.5.4:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-errors: 1.3.0
-      get-proto: 1.0.1
-      gopd: 1.2.0
-      set-function-name: 2.0.2
-
   remark-breaks@3.0.3:
     dependencies:
       '@types/mdast': 3.0.15
@@ -8174,22 +7821,6 @@ snapshots:
 
   set-blocking@2.0.0:
     optional: true
-
-  set-function-length@1.2.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      get-intrinsic: 1.3.0
-      gopd: 1.2.0
-      has-property-descriptors: 1.0.2
-
-  set-function-name@2.0.2:
-    dependencies:
-      define-data-property: 1.1.4
-      es-errors: 1.3.0
-      functions-have-names: 1.2.3
-      has-property-descriptors: 1.0.2
 
   set-harmonic-interval@1.0.1: {}
 
@@ -8463,10 +8094,6 @@ snapshots:
 
   tslib@1.14.1: {}
 
-  tslib@2.3.1: {}
-
-  tslib@2.5.3: {}
-
   tslib@2.6.2: {}
 
   tslib@2.8.1: {}
@@ -8484,8 +8111,6 @@ snapshots:
   type-fest@3.12.0: {}
 
   type-fest@4.40.1: {}
-
-  typed-styles@0.0.7: {}
 
   typescript@7.0.1-rc:
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,11 @@ allowBuilds:
   sharp: true
   unrs-resolver: true
 
+# Rolldown(Vite 8）无法解析 @popperjs/core 经 export* 重导出的 placements，
+# 这里给 Blueprint v6 legacy Popover 依赖的 popper 打补丁绕过（详见 vite.config.ts TODO）。
+patchedDependencies:
+  '@popperjs/core@2.11.8': patches/@popperjs__core@2.11.8.patch
+
 overrides:
   react-rating>@types/react: ^18.0.0
   # Pin two transitive deps to releases that predate the CI minimumReleaseAge

--- a/src/components/AccountManager.tsx
+++ b/src/components/AccountManager.tsx
@@ -7,12 +7,11 @@ import {
   Menu,
   MenuDivider,
   MenuItem,
-  Position,
+  PopoverNext,
   Tab,
   TabId,
   Tabs,
 } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
 
 import { useAtom } from 'jotai'
 import { ComponentType, FC, useState } from 'react'
@@ -150,9 +149,9 @@ export const AccountManager: ComponentType = withGlobalErrorBoundary(() => {
       <AccountAuthDialog open={open} onClose={() => setOpen(false)} />
       {authState.token ? (
         // BUTTOM_RIGHT设置防止弹出框撑大body超过100vw
-        <Popover2 content={<AccountMenu />} position={Position.BOTTOM_RIGHT}>
+        <PopoverNext content={<AccountMenu />} placement="bottom-end">
           <Button icon="user" text={!shrinked && authState.username} rightIcon="caret-down" />
-        </Popover2>
+        </PopoverNext>
       ) : (
         <Button className="ml-auto" icon="user" onClick={() => setOpen(true)}>
           {!shrinked && t.components.AccountManager.login_register}

--- a/src/components/FieldResetButton.tsx
+++ b/src/components/FieldResetButton.tsx
@@ -15,7 +15,7 @@ export const FieldResetButton = ({ disabled, onReset, ...buttonProps }: FieldRes
       disabled={disabled}
       className={clsx(
         'invisible pointer-events-none',
-        !disabled && '[.bp4-input-group:hover_&]:visible pointer-events-auto',
+        !disabled && '[.bp6-input-group:hover_&]:visible pointer-events-auto',
       )}
       icon="cross"
       onClick={() => onReset()}

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -1,5 +1,4 @@
-import { FormGroup, FormGroupProps, Icon, Tag } from '@blueprintjs/core'
-import { Popover2InteractionKind, Tooltip2, Tooltip2Props } from '@blueprintjs/popover2'
+import { FormGroup, FormGroupProps, Icon, Tag, PopoverInteractionKind, Tooltip, TooltipProps } from '@blueprintjs/core'
 
 import { ReactNode } from 'react'
 import { Control, Controller, ControllerProps, FieldError, FieldValues, Path } from 'react-hook-form'
@@ -20,7 +19,7 @@ export interface FormFieldProps<T extends FieldValues, P extends Path<T>> {
   label: ReactNode
   field: P
   ControllerProps?: Omit<ControllerProps<T, P>, 'name'>
-  description?: Tooltip2Props['content']
+  description?: TooltipProps['content']
   render?: (props: FormFieldRenderProps<T, P>) => ReactNode
 }
 
@@ -40,13 +39,13 @@ export const FormField = <T extends FieldValues, P extends Path<T>>({
         <span>
           {label}
           {description && (
-            <Tooltip2
+            <Tooltip
               className="!inline-block !mt-0"
-              interactionKind={Popover2InteractionKind.HOVER}
+              interactionKind={PopoverInteractionKind.HOVER}
               content={typeof description === 'string' ? <div className="max-w-sm">{description}</div> : description}
             >
               <Icon className="ml-1 text-slate-600" icon="help" />
-            </Tooltip2>
+            </Tooltip>
           )}
           {error && (
             <Tag minimal intent="danger" className="float-right">
@@ -75,7 +74,7 @@ export interface FormField2Props<T extends FieldValues> {
   label: ReactNode
   field: Path<T>
   asterisk?: boolean
-  description?: Tooltip2Props['content']
+  description?: TooltipProps['content']
 }
 
 export const FormField2 = <T extends FieldValues>({
@@ -95,13 +94,13 @@ export const FormField2 = <T extends FieldValues>({
         <div className="inline-block w-full">
           <span>{label}</span>
           {description && (
-            <Tooltip2
+            <Tooltip
               className="!inline-block !mt-0"
-              interactionKind={Popover2InteractionKind.HOVER}
+              interactionKind={PopoverInteractionKind.HOVER}
               content={typeof description === 'string' ? <div className="max-w-sm">{description}</div> : description}
             >
               <Icon className="ml-1 text-slate-600" icon="help" />
-            </Tooltip2>
+            </Tooltip>
           )}
           {asterisk && <span className="ml-1 text-slate-600">*</span>}
           {error && (

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -16,7 +16,7 @@ export function Markdown({ className, remarkPlugins, components, children, ...pr
         components={{
           ...components,
 
-          a: ({ children, ...props }) => {
+          a: ({ node, children, ...props }) => {
             // set target="_blank" for external links, see: https://github.com/remarkjs/react-markdown/issues/12#issuecomment-1479195975
             if (props.href?.startsWith('http')) {
               props.target = '_blank'

--- a/src/components/OperationCard.tsx
+++ b/src/components/OperationCard.tsx
@@ -1,5 +1,4 @@
-import { Button, Card, Elevation, H4, H5, Icon, Tag } from '@blueprintjs/core'
-import { Tooltip2 } from '@blueprintjs/popover2'
+import { Button, Card, Elevation, H4, H5, Icon, Tag, Tooltip } from '@blueprintjs/core'
 
 import clsx from 'clsx'
 import { useAtomValue } from 'jotai'
@@ -48,7 +47,7 @@ export const NeoOperationCard = ({
             onClick={onClick}
             onKeyDown={onKeyDown}
           >
-            <Tooltip2
+            <Tooltip
               content={operation.parsedContent.doc.title}
               className="whitespace-nowrap overflow-hidden text-ellipsis"
             >
@@ -62,7 +61,7 @@ export const NeoOperationCard = ({
                   </Tag>
                 )}
               </H4>
-            </Tooltip2>
+            </Tooltip>
 
             <div className="flex items-center text-slate-900">
               <NeoELevel
@@ -93,7 +92,7 @@ export const NeoOperationCard = ({
               </div>
               <div className="flex-1" />
 
-              <Tooltip2
+              <Tooltip
                 placement="top"
                 content={t.components.OperationCard.views_count({
                   count: operation.views,
@@ -103,13 +102,13 @@ export const NeoOperationCard = ({
                   <Icon icon="eye-open" className="mr-1.5" />
                   <span>{operation.views}</span>
                 </div>
-              </Tooltip2>
+              </Tooltip>
             </div>
 
             <div className="flex">
               <div>
                 <Icon icon="time" className="mr-1.5" />
-                <RelativeTime Tooltip2Props={{ placement: 'top' }} moment={operation.uploadTime} />
+                <RelativeTime TooltipProps={{ placement: 'top' }} moment={operation.uploadTime} />
               </div>
               <div className="flex-1" />
               <div className="text-zinc-500">
@@ -175,7 +174,7 @@ export const OperationCard = ({ operation }: { operation: Operation }) => {
                   <OperationRating className="text-sm" operation={operation} layout="horizontal" />
                 </div>
 
-                <Tooltip2
+                <Tooltip
                   placement="top"
                   content={t.components.OperationCard.views_count({
                     count: operation.views,
@@ -185,11 +184,11 @@ export const OperationCard = ({ operation }: { operation: Operation }) => {
                     <Icon icon="eye-open" className="mr-1.5" />
                     <span>{operation.views}</span>
                   </div>
-                </Tooltip2>
+                </Tooltip>
 
                 <div>
                   <Icon icon="time" className="mr-1.5" />
-                  <RelativeTime Tooltip2Props={{ placement: 'top' }} moment={operation.uploadTime} />
+                  <RelativeTime TooltipProps={{ placement: 'top' }} moment={operation.uploadTime} />
                 </div>
 
                 <div>
@@ -233,7 +232,7 @@ const OperatorTags = ({ operation }: { operation: Operation }) => {
         </Tag>
       ))}
       {groups?.map(({ name, opers }, index) => (
-        <Tooltip2
+        <Tooltip
           key={index}
           className="mr-2 last:mr-0 mb-1 last:mb-0"
           placement="top"
@@ -243,7 +242,7 @@ const OperatorTags = ({ operation }: { operation: Operation }) => {
           }
         >
           <Tag>[{name}]</Tag>
-        </Tooltip2>
+        </Tooltip>
       ))}
     </div>
   ) : (
@@ -277,7 +276,7 @@ const CardActions = ({
     />
   ) : (
     <div className={clsx('flex gap-1', className)}>
-      <Tooltip2
+      <Tooltip
         placement="bottom"
         content={<div className="max-w-sm dark:text-slate-900">{t.components.OperationCard.download_json}</div>}
       >
@@ -286,19 +285,19 @@ const CardActions = ({
           icon="download"
           onClick={() => handleLazyDownloadJSON(operation.id, operation.parsedContent.doc.title)}
         />
-      </Tooltip2>
-      <Tooltip2
+      </Tooltip>
+      <Tooltip
         placement="bottom"
         content={<div className="max-w-sm dark:text-slate-900">{t.components.OperationCard.copy_secret_code}</div>}
       >
         <Button small icon="clipboard" onClick={() => copyShortCode(operation)} />
-      </Tooltip2>
-      <Tooltip2
+      </Tooltip>
+      <Tooltip
         placement="bottom"
         content={<div className="max-w-sm dark:text-slate-900">{t.components.OperationCard.add_to_job_set}</div>}
       >
         <AddToOperationSetButton small icon="plus" operationIds={[operation.id]} />
-      </Tooltip2>
+      </Tooltip>
     </div>
   )
 }

--- a/src/components/OperationList.tsx
+++ b/src/components/OperationList.tsx
@@ -1,5 +1,4 @@
-import { Button, Callout, NonIdealState } from '@blueprintjs/core'
-import { Tooltip2 } from '@blueprintjs/popover2'
+import { Button, Callout, NonIdealState, Tooltip } from '@blueprintjs/core'
 
 import { UseOperationsParams, useOperations } from 'apis/operation'
 import { useAtomValue } from 'jotai'
@@ -103,11 +102,11 @@ export const OperationList: ComponentType<OperationListProps> = withSuspensable(
               </div>
             </details>
             <div className="absolute top-2 right-2 flex">
-              <Tooltip2 content={t.components.OperationList.only_loaded_items} placement="top">
+              <Tooltip content={t.components.OperationList.only_loaded_items} placement="top">
                 <Button minimal icon="tick" onClick={() => updateSelection(operations, [])}>
                   {t.components.OperationList.select_all}
                 </Button>
-              </Tooltip2>
+              </Tooltip>
               <Button minimal intent="danger" icon="trash" onClick={() => setSelectedOperations([])}>
                 {t.components.OperationList.clear}
               </Button>

--- a/src/components/OperationSetCard.tsx
+++ b/src/components/OperationSetCard.tsx
@@ -1,5 +1,4 @@
-import { Button, Card, Elevation, H4, Icon, Tag } from '@blueprintjs/core'
-import { Tooltip2 } from '@blueprintjs/popover2'
+import { Button, Card, Elevation, H4, Icon, Tag, Tooltip } from '@blueprintjs/core'
 
 import { copyShortCode } from 'services/operation'
 
@@ -18,12 +17,12 @@ export const NeoOperationSetCard = ({ operationSet }: { operationSet: OperationS
       <ReLink search={{ opset: operationSet.id }} className="block no-underline hover:no-underline hover:text-inherit">
         {/* title */}
         <div className="flex gap-1">
-          <Tooltip2 content={operationSet.name} className="flex-1 whitespace-nowrap overflow-hidden text-ellipsis">
+          <Tooltip content={operationSet.name} className="flex-1 whitespace-nowrap overflow-hidden text-ellipsis">
             <H4 className="p-0 m-0 mr-20 whitespace-nowrap overflow-hidden text-ellipsis">
               {operationSet.status === 'PRIVATE' && <Tag className="mr-1">{t.components.OperationSetCard.private}</Tag>}
               {operationSet.name}
             </H4>
-          </Tooltip2>
+          </Tooltip>
         </div>
         <div className="flex-1 flex flex-col my-3 gap-2 justify-center">
           <div className="text-gray-700 leading-normal">
@@ -44,7 +43,7 @@ export const NeoOperationSetCard = ({ operationSet }: { operationSet: OperationS
             </span>
 
             <Icon icon="time" className="ml-4 mr-1" />
-            <RelativeTime Tooltip2Props={{ placement: 'top' }} moment={operationSet.createTime} />
+            <RelativeTime TooltipProps={{ placement: 'top' }} moment={operationSet.createTime} />
           </div>
           <div className="flex-1" />
           <div className="text-zinc-500">
@@ -85,7 +84,7 @@ export const OperationSetCard = ({ operationSet }: { operationSet: OperationSetL
               </span>
 
               <Icon icon="time" className="ml-4 mr-1" />
-              <RelativeTime Tooltip2Props={{ placement: 'top' }} moment={operationSet.createTime} />
+              <RelativeTime TooltipProps={{ placement: 'top' }} moment={operationSet.createTime} />
             </div>
             <div>
               <Icon icon="user" className="mr-1.5" />
@@ -112,7 +111,7 @@ const CardActions = ({ className, operationSet }: { className?: string; operatio
   const t = useTranslation()
   return (
     <div className={className}>
-      <Tooltip2
+      <Tooltip
         placement="bottom"
         content={<div className="max-w-sm dark:text-slate-900">{t.components.OperationSetCard.copy_secret_code}</div>}
       >
@@ -124,7 +123,7 @@ const CardActions = ({ className, operationSet }: { className?: string; operatio
             copyShortCode(operationSet)
           }}
         />
-      </Tooltip2>
+      </Tooltip>
     </div>
   )
 }

--- a/src/components/Operations.tsx
+++ b/src/components/Operations.tsx
@@ -1,4 +1,4 @@
-﻿import { Button, ButtonGroup, Card, Divider, H6, InputGroup, Tab, Tabs } from '@blueprintjs/core'
+import { Button, ButtonGroup, Card, Divider, H6, InputGroup, Tab, Tabs } from '@blueprintjs/core'
 
 import { UseOperationsParams } from 'apis/operation'
 import clsx from 'clsx'
@@ -75,7 +75,6 @@ export const Operations: ComponentType = withSuspensable(() => {
                 className="max-w-md [&>input]:!rounded-md"
                 placeholder={t.components.Operations.search_placeholder}
                 leftIcon="search"
-                size={64}
                 large
                 type="search"
                 enterKeyHint="search"
@@ -149,7 +148,7 @@ export const Operations: ComponentType = withSuspensable(() => {
                     <Button
                       key={orderBy}
                       className={clsx(
-                        '!px-2 !py-1 !border-none [&>.bp4-icon]:!mr-1',
+                        '!px-2 !py-1 !border-none [&>.bp6-icon]:!mr-1',
                         !active && 'opacity-75 !font-normal',
                       )}
                       icon={icon}
@@ -173,7 +172,6 @@ export const Operations: ComponentType = withSuspensable(() => {
               className="max-w-md [&>input]:!rounded-md"
               placeholder={t.components.Operations.search_placeholder}
               leftIcon="search"
-              size={64}
               large
               type="search"
               enterKeyHint="search"

--- a/src/components/OperatorSelect.tsx
+++ b/src/components/OperatorSelect.tsx
@@ -1,6 +1,5 @@
 import { Classes, MenuItem } from '@blueprintjs/core'
-import { MenuItem2 } from '@blueprintjs/popover2'
-import { MultiSelect2 } from '@blueprintjs/select'
+import { MultiSelect } from '@blueprintjs/select'
 
 import clsx from 'clsx'
 import Fuse from 'fuse.js'
@@ -55,13 +54,13 @@ export const OperatorSelect: FC<OperatorSelectProps> = ({ className, operators, 
   }
 
   return (
-    <MultiSelect2<OperatorInfo>
+    <MultiSelect<OperatorInfo>
       className={clsx('', className)}
       query={query}
       onQueryChange={(query) => updateQuery(query, false)}
       items={OPERATORS}
       itemRenderer={(item, { handleClick, handleFocus, modifiers }) => (
-        <MenuItem2
+        <MenuItem
           roleStructure="listoption"
           className={clsx(
             'py-0 items-center',
@@ -115,7 +114,7 @@ export const OperatorSelect: FC<OperatorSelectProps> = ({ className, operators, 
         </div>
       )}
       popoverProps={{
-        popoverClassName: trimmedDebouncedQuery ? undefined : '[&_.bp4-popover2-content]:!p-0',
+        popoverClassName: trimmedDebouncedQuery ? undefined : '[&_.bp6-popover-content]:!p-0',
         placement: 'bottom-start',
         minimal: true,
         matchTargetWidth: true,

--- a/src/components/RelativeTime.tsx
+++ b/src/components/RelativeTime.tsx
@@ -1,4 +1,4 @@
-import { Tooltip2, Tooltip2Props } from '@blueprintjs/popover2'
+import { Tooltip, TooltipProps } from '@blueprintjs/core'
 
 import { FC, useEffect, useState } from 'react'
 
@@ -7,10 +7,10 @@ import { formatDateTime, formatRelativeTime } from '../utils/times'
 interface RelativeTimeProps {
   moment: string | number | Date
   className?: string
-  Tooltip2Props?: Omit<Tooltip2Props, 'content'>
+  TooltipProps?: Omit<TooltipProps, 'content'>
 }
 
-export const RelativeTime: FC<RelativeTimeProps> = ({ moment, className, Tooltip2Props }) => {
+export const RelativeTime: FC<RelativeTimeProps> = ({ moment, className, TooltipProps }) => {
   // Convert to timestamp if needed
   const timestamp = typeof moment === 'string' || moment instanceof Date ? new Date(moment).getTime() : moment
 
@@ -24,8 +24,8 @@ export const RelativeTime: FC<RelativeTimeProps> = ({ moment, className, Tooltip
   }, [timestamp])
 
   return (
-    <Tooltip2 content={formattedDate} {...Tooltip2Props} disabled={!formattedDate}>
+    <Tooltip content={formattedDate} {...TooltipProps} disabled={!formattedDate}>
       <span className={className}>{relativeTime}</span>
-    </Tooltip2>
+    </Tooltip>
   )
 }

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,10 +1,14 @@
-import { Button, ButtonProps, Classes, Label } from '@blueprintjs/core'
-import { Classes as Popover2Classes } from '@blueprintjs/popover2'
-import { QueryList, Select2, Select2Props, isCreateNewItem } from '@blueprintjs/select'
+import { Button, ButtonProps, Label } from '@blueprintjs/core'
+import {
+  QueryList,
+  Select as BlueprintSelect,
+  SelectProps as BlueprintSelectProps,
+  isCreateNewItem,
+} from '@blueprintjs/select'
 
 import clsx from 'clsx'
 
-interface SelectProps<T> extends Select2Props<T> {
+interface SelectProps<T> extends BlueprintSelectProps<T> {
   selectedItem?: T
   resetButtonProps?: ButtonProps
   canReset?: boolean
@@ -24,14 +28,13 @@ export const Select = <T,>({
 
   return (
     <Label className={clsx('!inline-flex items-center !mb-0', className)}>
-      <Select2
-        ref={patchHandleItemSelect}
+      <BlueprintSelect
         className="!mt-0"
         resetOnQuery={false} // 这个功能有无限 reset 的 bug，不要用
         inputProps={{
           ...inputProps,
           className: clsx(
-            '[&_.bp4-input]:rounded-md [&_.bp4-icon-search]:!m-[7px] [&_.bp4-button]:!p-[0_7px]',
+            '[&_.bp6-input]:rounded-md [&_.bp6-icon-search]:!m-[7px] [&_.bp6-button]:!p-[0_7px]',
             inputProps?.className,
           ),
         }}
@@ -54,22 +57,6 @@ export const Select = <T,>({
     </Label>
   )
 }
-
-// 临时实现 PR 里的内容： https://github.com/palantir/blueprint/pull/6070
-// TODO: 升级到 BP 5 后删除
-function patchHandleItemSelect(instance: Select2<any> | null) {
-  if (!instance || instance['handleItemSelect']._patched) return
-  instance['handleItemSelect'] = (item: unknown, event?: React.SyntheticEvent<HTMLElement>) => {
-    const target = event?.target as HTMLElement
-    const shouldDismiss =
-      target?.closest(`.${Classes.MENU_ITEM}`)?.classList?.contains(Popover2Classes.POPOVER2_DISMISS) ?? true
-
-    instance.setState({ isOpen: !shouldDismiss })
-    instance.props.onItemSelect?.(item, event)
-  }
-  instance['handleItemSelect']._patched = true
-}
-//
 
 // 修复 BP 的远古 bug：https://github.com/palantir/blueprint/issues/3751
 

--- a/src/components/Suggest.tsx
+++ b/src/components/Suggest.tsx
@@ -1,4 +1,4 @@
-import { Suggest2, Suggest2Props } from '@blueprintjs/select'
+import { Suggest as BlueprintSuggest, SuggestProps as BlueprintSuggestProps } from '@blueprintjs/select'
 
 import { noop } from 'lodash-es'
 import { useEffect, useRef } from 'react'
@@ -7,7 +7,7 @@ import { ControllerFieldState } from 'react-hook-form'
 import { UseDebouncedQueryParams, useDebouncedQuery } from '../utils/useDebouncedQuery'
 import { FieldResetButton } from './FieldResetButton'
 
-interface SuggestProps<T> extends Omit<Suggest2Props<T>, 'onQueryChange'>, UseDebouncedQueryParams {
+interface SuggestProps<T> extends Omit<BlueprintSuggestProps<T>, 'onQueryChange'>, UseDebouncedQueryParams {
   query?: string // controlled query, optional
   fieldState?: ControllerFieldState
   onReset?: () => void
@@ -24,11 +24,11 @@ export const Suggest = <T,>({
   itemListPredicate,
   selectedItem,
   inputProps,
-  ...suggest2Props
+  ...suggestProps
 }: SuggestProps<T>) => {
   // 禁用掉 focus 自动选中输入框文字的功能
   // https://github.com/palantir/blueprint/blob/b41f668461e63e2c20caf54a3248181fe01161c4/packages/select/src/components/suggest/suggest2.tsx#L229
-  const ref = useRef<Suggest2<T>>(null)
+  const ref = useRef<BlueprintSuggest<T>>(null)
   if (ref.current && ref.current['selectText'] !== noop) {
     ref.current['selectText'] = noop
   }
@@ -47,7 +47,7 @@ export const Suggest = <T,>({
   }, [fieldState, updateQuery])
 
   return (
-    <Suggest2<T>
+    <BlueprintSuggest<T>
       ref={ref}
       query={query}
       onQueryChange={(query) => updateQuery(query, false)}
@@ -79,7 +79,7 @@ export const Suggest = <T,>({
       popoverProps={{
         placement: 'bottom-start',
       }}
-      {...suggest2Props}
+      {...suggestProps}
     />
   )
 }

--- a/src/components/ThemeSwitchButton.tsx
+++ b/src/components/ThemeSwitchButton.tsx
@@ -1,5 +1,4 @@
-import { Button, Menu, MenuItem, Position } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
+import { Button, Menu, MenuItem, PopoverNext } from '@blueprintjs/core'
 
 import { useCurrentSize } from 'utils/useCurrenSize'
 
@@ -46,11 +45,11 @@ export const ThemeSwitchButton = () => {
   )
 
   return (
-    <Popover2
+    <PopoverNext
       content={themeMenu}
-      position={Position.BOTTOM}
+      placement="bottom"
       renderTarget={({ isOpen, ref, ...targetProps }) => (
-        <div className="bp4-popover2-target !mt-0 flex items-center" ref={ref}>
+        <div className="bp6-popover-target !mt-0 flex items-center" ref={ref}>
           <Button
             {...targetProps}
             active={isOpen}

--- a/src/components/Toaster.tsx
+++ b/src/components/Toaster.tsx
@@ -1,6 +1,36 @@
-import { Position, Toaster } from '@blueprintjs/core'
+import { OverlayToaster, Position, type ToastProps, type Toaster } from '@blueprintjs/core'
 
-export const AppToaster = Toaster.create({
+// v6 起 OverlayToaster.create 返回 Promise（内部改用 React 18 createRoot 异步挂载）。
+// 这里用一个同步门面缓冲就绪前的调用，对外保持历史上的同步 AppToaster API。
+let toaster: Toaster | undefined
+const toasterPromise = OverlayToaster.create({
   position: Position.BOTTOM_LEFT,
   className: '!fixed',
 })
+void toasterPromise.then((t) => {
+  toaster = t
+})
+
+export const AppToaster = {
+  show(props: ToastProps, key?: string): string | undefined {
+    if (toaster) {
+      return toaster.show(props, key)
+    }
+    void toasterPromise.then((t) => t.show(props, key))
+    return key
+  },
+  dismiss(key: string) {
+    if (toaster) {
+      toaster.dismiss(key)
+      return
+    }
+    void toasterPromise.then((t) => t.dismiss(key))
+  },
+  clear() {
+    if (toaster) {
+      toaster.clear()
+      return
+    }
+    void toasterPromise.then((t) => t.clear())
+  },
+}

--- a/src/components/UserCard.tsx
+++ b/src/components/UserCard.tsx
@@ -1,4 +1,4 @@
-﻿import { Button, Card } from '@blueprintjs/core'
+import { Button, Card } from '@blueprintjs/core'
 
 import { MaaUserInfo, MaaUserInfoRelationEnum } from 'maa-copilot-client'
 import { FC, useEffect, useState } from 'react'
@@ -31,7 +31,7 @@ export const UserCard: FC<UserCardProps> = ({ user, showFollowButton = true }) =
   const isSelf = relation === MaaUserInfoRelationEnum.Self
   const followButtonText = resolveFollowButtonText(t.components.UserProfile, relation)
   const followButtonClassName = [
-    'w-24 h-8 shrink-0 rounded !inline-flex !items-center !justify-center !px-3 !text-center !font-medium !shadow-none [&_.bp4-button-text]:w-full [&_.bp4-button-text]:text-center',
+    'w-24 h-8 shrink-0 rounded !inline-flex !items-center !justify-center !px-3 !text-center !font-medium !shadow-none [&_.bp6-button-text]:w-full [&_.bp6-button-text]:text-center',
     !following
       ? '!border !border-blue-600 !bg-blue-600 !text-white hover:!border-blue-700 hover:!bg-blue-700 dark:!border-blue-500 dark:!bg-blue-500 dark:hover:!border-blue-400 dark:hover:!bg-blue-400'
       : '!border !border-slate-200 !bg-slate-200 !text-slate-700 hover:!border-slate-300 hover:!bg-slate-300 dark:!border-slate-600 dark:!bg-slate-700 dark:!text-slate-100 dark:hover:!border-slate-500 dark:hover:!bg-slate-600',

--- a/src/components/account/AuthFormShared.tsx
+++ b/src/components/account/AuthFormShared.tsx
@@ -1,4 +1,4 @@
-import { InputGroup, InputGroupProps2 } from '@blueprintjs/core'
+import { InputGroup, InputGroupProps } from '@blueprintjs/core'
 
 import { ControllerProps, FieldValues, UseControllerProps } from 'react-hook-form'
 
@@ -63,7 +63,7 @@ export type AuthFormFieldProps<T extends FieldValues> = Pick<FormFieldProps<T, a
   label?: string
   register?: boolean
   autoComplete?: string
-  inputGroupProps?: (...params: Parameters<ControllerProps<T, any>['render']>) => InputGroupProps2
+  inputGroupProps?: (...params: Parameters<ControllerProps<T, any>['render']>) => InputGroupProps
 }
 
 export const AuthFormEmailField = <T extends FieldValues>({

--- a/src/components/drawer/NavAside.tsx
+++ b/src/components/drawer/NavAside.tsx
@@ -1,5 +1,4 @@
-import { Drawer, Menu, MenuDivider } from '@blueprintjs/core'
-import { MenuItem2 } from '@blueprintjs/popover2'
+import { Drawer, Menu, MenuDivider, MenuItem } from '@blueprintjs/core'
 
 import { useLinks } from 'hooks/useLinks'
 import { useAtomValue, useSetAtom } from 'jotai'
@@ -32,7 +31,7 @@ export const NavAside = () => {
         onClose={() => toggleNav()}
         position="left"
         size="100%"
-        portalClassName="[&>.bp4-overlay-container]:z-10"
+        portalClassName="[&>.bp6-overlay-container]:z-10"
         backdropClassName="bg-transparent"
         className="bg-transparent backdrop-blur-lg overflow-y-auto mt-14 p-2"
       >
@@ -40,7 +39,7 @@ export const NavAside = () => {
           {NAV_LINKS.map((link) => (
             <NavLink key={link.to} to={link.to} className="block !no-underline">
               {({ isActive }) => (
-                <MenuItem2
+                <MenuItem
                   key={link.to}
                   icon={link.icon}
                   active={isActive}
@@ -53,7 +52,7 @@ export const NavAside = () => {
             </NavLink>
           ))}
           <MenuDivider />
-          <MenuItem2
+          <MenuItem
             icon="folder-new"
             text={t.components.drawer.NavAside.create_job_set}
             className="p-2 rounded-md"
@@ -64,7 +63,7 @@ export const NavAside = () => {
           />
           <AnnPanel
             trigger={({ handleClick }) => (
-              <MenuItem2
+              <MenuItem
                 icon="info-sign"
                 text={t.components.drawer.NavAside.announcement}
                 className="p-2 rounded-md"

--- a/src/components/editor/CardOptions.tsx
+++ b/src/components/editor/CardOptions.tsx
@@ -1,5 +1,4 @@
-import { Button, ButtonProps, Menu, MenuItem } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
+import { Button, ButtonProps, Menu, MenuItem, PopoverNext } from '@blueprintjs/core'
 
 import clsx from 'clsx'
 import { FC } from 'react'
@@ -38,8 +37,8 @@ export const CardDeleteOption: FC<ButtonProps> = ({ className, onClick, ...props
   const t = useTranslation()
 
   return (
-    <Popover2
-      position="right"
+    <PopoverNext
+      placement="right"
       content={
         <Menu className="p-0">
           <MenuItem intent="danger" text={t.components.editor.CardOptions.delete} icon="trash" onClick={onClick} />
@@ -53,6 +52,6 @@ export const CardDeleteOption: FC<ButtonProps> = ({ className, onClick, ...props
         className={clsx('-my-2', className)}
         {...props}
       />
-    </Popover2>
+    </PopoverNext>
   )
 }

--- a/src/components/editor/DetailedSelect.tsx
+++ b/src/components/editor/DetailedSelect.tsx
@@ -1,5 +1,5 @@
 import { Classes, H6, Icon, IconName, MenuItem, MenuItemProps } from '@blueprintjs/core'
-import { Select2Props } from '@blueprintjs/select'
+import { SelectProps } from '@blueprintjs/select'
 
 import clsx from 'clsx'
 import { ReactNode } from 'react'
@@ -24,7 +24,7 @@ export interface DetailedSelectChoice {
 }
 
 export const DetailedSelect: FCC<
-  Omit<Select2Props<DetailedSelectItem>, 'itemRenderer' | 'onItemSelect' | 'itemDisabled'> & {
+  Omit<SelectProps<DetailedSelectItem>, 'itemRenderer' | 'onItemSelect' | 'itemDisabled'> & {
     value?: string | number
     onItemSelect: (item: DetailedSelectChoice) => void
   }

--- a/src/components/editor/NumericInput2.tsx
+++ b/src/components/editor/NumericInput2.tsx
@@ -4,7 +4,9 @@ import clsx from 'clsx'
 import { clamp, noop } from 'lodash-es'
 import { WheelEventHandler, useCallback, useEffect, useRef, useState } from 'react'
 
-type MixedNumericInputProps = HTMLInputProps & NumericInputProps
+// v6 起 NumericInputProps.size 是 Blueprint 的 Size 变体，与 HTMLInputProps.size(number) 冲突，
+// 交叉后会塌成 never，这里从 HTML props 中剔除 size，保留 Blueprint 的 size 语义。
+type MixedNumericInputProps = Omit<HTMLInputProps, 'size'> & NumericInputProps
 
 export interface NumericInput2Props extends MixedNumericInputProps {
   intOnly?: boolean

--- a/src/components/editor/OperationEditor.tsx
+++ b/src/components/editor/OperationEditor.tsx
@@ -1,5 +1,15 @@
-import { AnchorButton, Button, ButtonGroup, Callout, H4, Icon, InputGroup, MenuItem, TextArea } from '@blueprintjs/core'
-import { Tooltip2 } from '@blueprintjs/popover2'
+import {
+  AnchorButton,
+  Button,
+  ButtonGroup,
+  Callout,
+  H4,
+  Icon,
+  InputGroup,
+  MenuItem,
+  TextArea,
+  Tooltip,
+} from '@blueprintjs/core'
 
 import { useLevels } from 'apis/level'
 import clsx from 'clsx'
@@ -111,7 +121,7 @@ export const StageNameInput: FC<{
           itemListPredicate={(query) => (query ? fuse.search(query).map((el) => el.item) : levels)}
           fieldState={fieldState}
           onReset={() => onChange('')}
-          className={clsx('flex-grow mr-2', isLoading && 'bp4-skeleton')}
+          className={clsx('flex-grow mr-2', isLoading && 'bp6-skeleton')}
           disabled={isLoading}
           itemRenderer={(item, { handleClick, handleFocus, modifiers }) => (
             <MenuItem
@@ -149,9 +159,9 @@ export const StageNameInput: FC<{
             onBlur,
           }}
         />
-        <Tooltip2 placement="top" content={t.components.editor.OperationEditor.view_in_prts_map}>
+        <Tooltip placement="top" content={t.components.editor.OperationEditor.view_in_prts_map}>
           <AnchorButton large icon="share" target="_blank" href={prtsMapUrl} disabled={!prtsMapUrl} />
-        </Tooltip2>
+        </Tooltip>
       </div>
     </FormField2>
   )
@@ -323,7 +333,7 @@ export const OperationEditor: FC<OperationEditorProps> = ({
                     <TextArea
                       fill
                       rows={4}
-                      growVertically
+                      autoResize
                       large
                       id="doc.details"
                       placeholder={t.components.editor.OperationEditor.description_placeholder}

--- a/src/components/editor/action/EditorActionAdd.tsx
+++ b/src/components/editor/action/EditorActionAdd.tsx
@@ -353,7 +353,7 @@ export const EditorActionAdd = ({
                   <TextArea
                     fill
                     rows={2}
-                    growVertically
+                    autoResize
                     large
                     id="doc"
                     placeholder={t.components.editor.action.EditorActionAdd.description_placeholder}

--- a/src/components/editor/action/EditorActionDocColor.tsx
+++ b/src/components/editor/action/EditorActionDocColor.tsx
@@ -1,5 +1,5 @@
 import { Button, Icon, MenuItem } from '@blueprintjs/core'
-import { Select2 } from '@blueprintjs/select'
+import { Select } from '@blueprintjs/select'
 
 import { useController } from 'react-hook-form'
 import { SetOptional } from 'type-fest'
@@ -35,7 +35,7 @@ export const EditorActionDocColor = ({ name = 'docColor', control, ...controller
       error={errors[name]}
       description={t.components.editor.action.EditorActionDocColor.color_description}
     >
-      <Select2
+      <Select
         filterable={false}
         items={actionDocColors}
         itemRenderer={(color, { handleClick, handleFocus, modifiers }) => (
@@ -61,7 +61,7 @@ export const EditorActionDocColor = ({ name = 'docColor', control, ...controller
           <Icon icon="full-circle" color={selected?.value} />
           <span style={{ color: selected?.value }}>{selected?.title()}</span>
         </Button>
-      </Select2>
+      </Select>
     </FormField2>
   )
 }

--- a/src/components/editor/action/EditorActionOperatorDirection.tsx
+++ b/src/components/editor/action/EditorActionOperatorDirection.tsx
@@ -1,5 +1,5 @@
 import { Button, MenuItem } from '@blueprintjs/core'
-import { Select2 } from '@blueprintjs/select'
+import { Select } from '@blueprintjs/select'
 
 import { useController } from 'react-hook-form'
 import { SetOptional } from 'type-fest'
@@ -44,7 +44,7 @@ export const EditorActionOperatorDirection = ({
       error={errors[name]}
       description={t.components.editor.action.EditorActionOperatorDirection.direction_description}
     >
-      <Select2<OperatorDirection>
+      <Select<OperatorDirection>
         filterable={false}
         resetOnSelect={true}
         items={operatorDirections}
@@ -69,7 +69,7 @@ export const EditorActionOperatorDirection = ({
           onBlur={onBlur}
           ref={ref}
         />
-      </Select2>
+      </Select>
     </FormField2>
   )
 }

--- a/src/components/editor/floatingMap/FloatingMap.tsx
+++ b/src/components/editor/floatingMap/FloatingMap.tsx
@@ -185,7 +185,7 @@ export function FloatingMap() {
                 {mapStatus === MapStatus.Loading && (
                   <NonIdealState
                     className="absolute inset-0 bg-gray-900/50 [&_*]:!text-white"
-                    icon={<Spinner className="[&_.bp4-spinner-head]:stroke-current" />}
+                    icon={<Spinner className="[&_.bp6-spinner-head]:stroke-current" />}
                     description={
                       iframeWindow ? undefined : t.components.editor.floatingMap.FloatingMap.waiting_connection
                     }

--- a/src/components/editor/operator/EditorOperatorSkill.tsx
+++ b/src/components/editor/operator/EditorOperatorSkill.tsx
@@ -1,5 +1,5 @@
 import { Button, IconName, MenuItem } from '@blueprintjs/core'
-import { Select2 } from '@blueprintjs/select'
+import { Select } from '@blueprintjs/select'
 
 import { useMemo } from 'react'
 import { useController } from 'react-hook-form'
@@ -64,7 +64,7 @@ export const EditorOperatorSkill = ({ name, control }: EditorOperatorSkillProps)
   const selected = items.find((item) => item.value === (value ?? 0))
 
   return (
-    <Select2<EditorOperatorSkillChoice>
+    <Select<EditorOperatorSkillChoice>
       filterable={false}
       resetOnSelect={true}
       items={items}
@@ -89,6 +89,6 @@ export const EditorOperatorSkill = ({ name, control }: EditorOperatorSkillProps)
         onBlur={onBlur}
         ref={ref}
       />
-    </Select2>
+    </Select>
   )
 }

--- a/src/components/editor/operator/EditorPerformerAdd.tsx
+++ b/src/components/editor/operator/EditorPerformerAdd.tsx
@@ -1,5 +1,5 @@
 import { Button, Card, MenuItem } from '@blueprintjs/core'
-import { Select2 } from '@blueprintjs/select'
+import { Select } from '@blueprintjs/select'
 
 import { FC, useMemo } from 'react'
 
@@ -59,7 +59,7 @@ export const EditorPerformerAdd: FC<EditorPerformerAddProps> = ({
     () => (
       <>
         {t.components.editor.operator.EditorPerformerAdd.add}
-        <Select2<PerformerSelectItem>
+        <Select<PerformerSelectItem>
           filterable={false}
           items={performerSelectItems}
           className="ml-1"
@@ -75,7 +75,7 @@ export const EditorPerformerAdd: FC<EditorPerformerAddProps> = ({
           )}
         >
           <Button large text={selectedItem.label} rightIcon="double-caret-vertical" />
-        </Select2>
+        </Select>
       </>
     ),
     [mode, onModeChange, selectedItem, performerSelectItems, t],

--- a/src/components/editor/operator/sheet/SheetOperatorSkillAbout.tsx
+++ b/src/components/editor/operator/sheet/SheetOperatorSkillAbout.tsx
@@ -1,5 +1,4 @@
-import { Button, Classes, Icon } from '@blueprintjs/core'
-import { Popover2, Tooltip2 } from '@blueprintjs/popover2'
+import { Button, Classes, Icon, PopoverNext, Tooltip } from '@blueprintjs/core'
 
 import clsx from 'clsx'
 import { useForm } from 'react-hook-form'
@@ -87,12 +86,12 @@ export const SkillAboutTrigger = ({ operator, onSkillChange }: SkillAboutProps) 
           type="submit"
           className={Classes.POPOVER_DISMISS}
         />
-        <Tooltip2
+        <Tooltip
           content={t.components.editor.operator.sheet.SheetOperatorSkillAbout.default_settings_tooltip}
           className="ml-1"
         >
           <Icon icon="help" />
-        </Tooltip2>
+        </Tooltip>
       </div>
     </form>
   )
@@ -124,9 +123,9 @@ export const SkillAboutTrigger = ({ operator, onSkillChange }: SkillAboutProps) 
       role="presentation"
       className="cursor-pointer"
     >
-      <Popover2 content={SkillAboutForm} disabled={!operator}>
+      <PopoverNext content={SkillAboutForm} disabled={!operator}>
         {SkillAboutTrigger}
-      </Popover2>
+      </PopoverNext>
     </div>
   )
 }

--- a/src/components/editor/operator/sheet/sheetGroup/SheetGroupItem.tsx
+++ b/src/components/editor/operator/sheet/sheetGroup/SheetGroupItem.tsx
@@ -1,5 +1,4 @@
-import { Alert, Button, Card, Collapse, Icon, Intent, Menu, MenuItem } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
+import { Alert, Button, Card, Collapse, Icon, Intent, Menu, MenuItem, PopoverNext } from '@blueprintjs/core'
 
 import clsx from 'clsx'
 import { useAtom } from 'jotai'
@@ -291,7 +290,7 @@ const GroupPinOption: FC<GroupPinOptionProp> = ({ pinned, onPinChange, isDuplica
       : t.components.editor.operator.sheet.sheetGroup.SheetGroupItem.add_to_favorites
 
   return (
-    <Popover2
+    <PopoverNext
       disabled={!pinned && !isDuplicate}
       content={
         <Menu className="p-0">
@@ -309,6 +308,6 @@ const GroupPinOption: FC<GroupPinOptionProp> = ({ pinned, onPinChange, isDuplica
         title={pinText}
         onClick={pinned || isDuplicate ? undefined : onPinChange}
       />
-    </Popover2>
+    </PopoverNext>
   )
 }

--- a/src/components/editor/operator/sheet/sheetGroup/SheetOperatorEditor.tsx
+++ b/src/components/editor/operator/sheet/sheetGroup/SheetOperatorEditor.tsx
@@ -1,5 +1,4 @@
-import { Button, Card, Classes, Collapse, H6, Icon, Intent, Position } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
+import { Button, Card, Classes, Collapse, H6, Icon, Intent, PopoverNext } from '@blueprintjs/core'
 
 import clsx from 'clsx'
 import { useAtomValue } from 'jotai'
@@ -21,10 +20,10 @@ export const SheetOperatorEditor: FC<SheetOperatorEditorProp> = ({ ...SheetOpera
   const t = useTranslation()
 
   return (
-    <Popover2
+    <PopoverNext
       className="w-full"
       content={<SheetOperatorEditorForm {...SheetOperatorEditorFormProps} />}
-      position={Position.TOP}
+      placement="top"
     >
       <Card
         className="flex items-center justify-center"
@@ -33,7 +32,7 @@ export const SheetOperatorEditor: FC<SheetOperatorEditorProp> = ({ ...SheetOpera
       >
         <Icon icon="plus" size={30} />
       </Card>
-    </Popover2>
+    </PopoverNext>
   )
 }
 
@@ -178,7 +177,7 @@ const SheetOperatorEditorForm: FC<SheetOperatorEditorFormProp> = ({ name, opers 
             className={Classes.POPOVER_DISMISS}
             type="submit"
           />
-          <Popover2
+          <PopoverNext
             captureDismiss
             content={
               <div className="flex items-center">
@@ -195,14 +194,14 @@ const SheetOperatorEditorForm: FC<SheetOperatorEditorFormProp> = ({ name, opers 
                 />
               </div>
             }
-            position={Position.TOP}
+            placement="top"
           >
             <Button
               intent={Intent.DANGER}
               className="ml-1"
               text={t.components.editor.operator.sheet.sheetGroup.SheetOperatorEditor.reset}
             />
-          </Popover2>
+          </PopoverNext>
         </div>
       </form>
     </SheetContainerSkeleton>

--- a/src/components/editor/operator/sheet/sheetOperator/ProfClassificationWithFilters.tsx
+++ b/src/components/editor/operator/sheet/sheetOperator/ProfClassificationWithFilters.tsx
@@ -1,5 +1,4 @@
-import { Button, Divider, H4, H5 } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
+import { Button, Divider, H4, H5, PopoverNext } from '@blueprintjs/core'
 
 import clsx from 'clsx'
 import { useAtomValue } from 'jotai'
@@ -80,7 +79,7 @@ export const ProfClassificationWithFilters: FC<ProfClassificationWithFiltersProp
 
   const ToolBox = (
     <div className="flex flex-col absolute bottom-0">
-      <Popover2
+      <PopoverNext
         content={
           <>
             <OperatorRaritySelect />
@@ -88,7 +87,7 @@ export const ProfClassificationWithFilters: FC<ProfClassificationWithFiltersProp
         }
       >
         <Button minimal icon="filter-list" />
-      </Popover2>
+      </PopoverNext>
       <OperatorMutipleSelect />
       <OperatorBackToTop {...{ toTop }} />
     </div>

--- a/src/components/editor/operator/sheet/sheetOperator/SheetOperatorItem.tsx
+++ b/src/components/editor/operator/sheet/sheetOperator/SheetOperatorItem.tsx
@@ -1,5 +1,4 @@
-import { Button, Card, Icon, Intent } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
+import { Button, Card, Icon, Intent, PopoverNext } from '@blueprintjs/core'
 
 import clsx from 'clsx'
 import { useAtom } from 'jotai'
@@ -105,7 +104,7 @@ export const SheetOperatorItem: FC<SheetOperatorItemProp> = ({ name }) => {
             {(() => {
               const isFavDuplicate = favOperators.find(({ name: existedName }) => existedName === name)
               return (
-                <Popover2
+                <PopoverNext
                   content={
                     <Button minimal onClick={onPinnedChange}>
                       <Icon icon={pinned ? 'pin' : 'warning-sign'} className={clsx(pinned && '-rotate-45')} />
@@ -123,7 +122,7 @@ export const SheetOperatorItem: FC<SheetOperatorItemProp> = ({ name }) => {
                     className={clsx(pinned && '-rotate-45')}
                     onClick={!pinned && !isFavDuplicate ? onPinnedChange : undefined}
                   />
-                </Popover2>
+                </PopoverNext>
               )
             })()}
           </div>

--- a/src/components/editor/source/SourceEditor.tsx
+++ b/src/components/editor/source/SourceEditor.tsx
@@ -98,7 +98,7 @@ export const SourceEditor: FC<SourceEditorProps> = ({
           <Tooltip
             className="flex-1"
             content={t.components.editor.source.SourceEditor.see_errors_in_form}
-            position="bottom"
+            placement="bottom"
             disabled={!hasValidationErrors}
           >
             <Callout

--- a/src/components/editor/source/SourceEditor.tsx
+++ b/src/components/editor/source/SourceEditor.tsx
@@ -1,5 +1,4 @@
-import { Callout } from '@blueprintjs/core'
-import { Tooltip2 } from '@blueprintjs/popover2'
+import { Callout, Tooltip } from '@blueprintjs/core'
 
 import camelcaseKeys from 'camelcase-keys'
 import { FC, useMemo, useState } from 'react'
@@ -96,7 +95,7 @@ export const SourceEditor: FC<SourceEditorProps> = ({
               intent={jsonError ? 'warning' : 'success'}
             />
           </div>
-          <Tooltip2
+          <Tooltip
             className="flex-1"
             content={t.components.editor.source.SourceEditor.see_errors_in_form}
             position="bottom"
@@ -110,7 +109,7 @@ export const SourceEditor: FC<SourceEditorProps> = ({
               })}
               intent={hasValidationErrors ? 'warning' : 'success'}
             />
-          </Tooltip2>
+          </Tooltip>
         </div>
         <textarea
           className="mt-4 p-1 flex-grow bg-white text-xm font-mono resize-none focus:outline focus:outline-2 focus:outline-blue-300 dark:bg-slate-900 dark:text-white"

--- a/src/components/editor/source/SourceEditorHeader.tsx
+++ b/src/components/editor/source/SourceEditorHeader.tsx
@@ -1,5 +1,4 @@
-import { Button, Icon, Menu, MenuItem } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
+import { Button, Icon, Menu, MenuItem, PopoverNext } from '@blueprintjs/core'
 
 import { FC, useState } from 'react'
 
@@ -63,9 +62,10 @@ export const SourceEditorHeader: FC<SourceEditorHeaderProps> = ({ text, onChange
 
       <div className="flex-1" />
 
-      <Popover2
-        minimal
-        position="bottom-left"
+      <PopoverNext
+        animation="minimal"
+        arrow={false}
+        placement="bottom-start"
         isOpen={importDropdownOpen}
         onClose={() => setImportDropdownOpen(false)}
         content={
@@ -82,11 +82,12 @@ export const SourceEditorHeader: FC<SourceEditorHeaderProps> = ({ text, onChange
           rightIcon="caret-down"
           onClick={() => setImportDropdownOpen(!importDropdownOpen)}
         />
-      </Popover2>
+      </PopoverNext>
 
-      <Popover2
-        minimal
-        position="bottom-left"
+      <PopoverNext
+        animation="minimal"
+        arrow={false}
+        placement="bottom-start"
         content={
           <Menu>
             <MenuItem icon="clipboard" text={t.components.editor.source.SourceEditorHeader.copy} onClick={handleCopy} />
@@ -104,7 +105,7 @@ export const SourceEditorHeader: FC<SourceEditorHeaderProps> = ({ text, onChange
           text={t.components.editor.source.SourceEditorHeader.export}
           rightIcon="caret-down"
         />
-      </Popover2>
+      </PopoverNext>
     </>
   )
 }

--- a/src/components/editor/useAutosave.tsx
+++ b/src/components/editor/useAutosave.tsx
@@ -1,5 +1,4 @@
-import { Alert, Button, ButtonProps, Callout, H4, Menu, MenuItem } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
+import { Alert, Button, ButtonProps, Callout, H4, Menu, MenuItem, PopoverNext } from '@blueprintjs/core'
 
 import { first, isEqual } from 'lodash-es'
 import { ReactNode, useCallback, useEffect, useRef, useState } from 'react'
@@ -144,7 +143,7 @@ export const AutosaveSheet = <T,>({
 
   return (
     <>
-      <Popover2
+      <PopoverNext
         content={
           <>
             <Callout intent="primary">
@@ -186,7 +185,7 @@ export const AutosaveSheet = <T,>({
           }
           {...buttonProps}
         />
-      </Popover2>
+      </PopoverNext>
 
       <Alert
         isOpen={restoreDialogOpen}

--- a/src/components/editor2/EditorToolbar.tsx
+++ b/src/components/editor2/EditorToolbar.tsx
@@ -1,5 +1,15 @@
-import { Button, ButtonProps, Callout, H2, Icon, Menu, MenuDivider, MenuItem, Tag } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
+import {
+  Button,
+  ButtonProps,
+  Callout,
+  H2,
+  Icon,
+  Menu,
+  MenuDivider,
+  MenuItem,
+  Tag,
+  PopoverNext,
+} from '@blueprintjs/core'
 
 import clsx from 'clsx'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
@@ -32,7 +42,7 @@ export const EditorToolbar: FC<EditorToolbarProps> = ({ subtitle, submitAction, 
   } satisfies ButtonProps
 
   return (
-    <div className="px-4 md:px-8 flex items-center flex-wrap [&_.bp4-button-text]:leading-none bg-white dark:bg-[#383e47]">
+    <div className="px-4 md:px-8 flex items-center flex-wrap [&_.bp6-button-text]:leading-none bg-white dark:bg-[#383e47]">
       <Icon icon="properties" />
       <div className="ml-2 flex items-baseline">
         <H2 className="!text-base mb-0">{t.components.editor2.EditorToolbar.title}</H2>
@@ -109,7 +119,7 @@ const AutoSaveButton = (buttonProps: ButtonProps) => {
   const setEditorState = useSetAtom(editorAtoms.editor)
   const [isOpen, setIsOpen] = useState(false)
   return (
-    <Popover2
+    <PopoverNext
       content={
         isOpen ? (
           <>
@@ -171,7 +181,7 @@ const AutoSaveButton = (buttonProps: ButtonProps) => {
       onClosed={() => setIsOpen(false)}
     >
       <Button {...buttonProps} icon="projects" title={t.components.editor2.EditorToolbar.auto_save} />
-    </Popover2>
+    </PopoverNext>
   )
 }
 
@@ -196,7 +206,7 @@ const HistoryButtons = (buttonProps: ButtonProps) => {
         disabled={!canRedo}
         onClick={redo}
       />
-      <Popover2
+      <PopoverNext
         content={
           isOpen ? (
             <Menu>
@@ -234,7 +244,7 @@ const HistoryButtons = (buttonProps: ButtonProps) => {
           title={t.components.editor2.EditorToolbar.undo_history}
           text={history.index + 1 + '/' + history.stack.length}
         />
-      </Popover2>
+      </PopoverNext>
     </>
   )
 }
@@ -246,7 +256,7 @@ const ErrorButton = (buttonProps: ButtonProps) => {
   const [isOpen, setIsOpen] = useState(false)
   const allErrors = globalErrors.concat(Object.values(entityErrors).flat())
   return (
-    <Popover2
+    <PopoverNext
       content={
         isOpen ? (
           <>
@@ -280,7 +290,7 @@ const ErrorButton = (buttonProps: ButtonProps) => {
         }
         text={allErrors.length || <Icon className="!-ml-px" icon="small-tick" />}
       />
-    </Popover2>
+    </PopoverNext>
   )
 }
 

--- a/src/components/editor2/InfoEditor.tsx
+++ b/src/components/editor2/InfoEditor.tsx
@@ -26,7 +26,7 @@ export const InfoEditor = memo(({ className }: InfoEditorProps) => {
   return (
     <div
       className={clsx(
-        'p-4 md:[&>.bp4-form-group]:flex-row md:[&>.bp4-form-group>.bp4-label]:w-20',
+        'p-4 md:[&>.bp6-form-group]:flex-row md:[&>.bp6-form-group>.bp6-label]:w-20',
         '[&_[type="text"]]:!border-0 [&_textarea]:!outline-none [&_[type="text"]]:shadow-[inset_0_0_2px_0_rgba(0,0,0,0.4)] [&_textarea:not(:focus)]:!shadow-[inset_0_0_2px_0_rgba(0,0,0,0.4)]',
         className,
       )}

--- a/src/components/editor2/LevelSelect.tsx
+++ b/src/components/editor2/LevelSelect.tsx
@@ -1,5 +1,4 @@
-import { AnchorButton, Classes, MenuDivider, MenuItem } from '@blueprintjs/core'
-import { Tooltip2 } from '@blueprintjs/popover2'
+import { AnchorButton, Classes, MenuDivider, MenuItem, Tooltip } from '@blueprintjs/core'
 import { getCreateNewItem } from '@blueprintjs/select'
 
 import clsx from 'clsx'
@@ -142,7 +141,7 @@ export const LevelSelect: FC<LevelSelectProps> = ({
         onQueryChange={(query) => updateQuery(query, false)}
         onReset={() => onChange('')}
         disabled={isLoading}
-        className={clsx('items-stretch', isLoading && 'bp4-skeleton', className)}
+        className={clsx('items-stretch', isLoading && 'bp6-skeleton', className)}
         itemsEqual={(a, b) => a.stageId === b.stageId}
         itemDisabled={(item) => item.stageId === 'header'} // 避免 header 被选中为 active
         itemRenderer={(item, { handleClick, handleFocus, modifiers }) =>
@@ -201,7 +200,7 @@ export const LevelSelect: FC<LevelSelectProps> = ({
           },
         }}
       />
-      <Tooltip2 placement="top" content={t.components.editor2.LevelSelect.view_external}>
+      <Tooltip placement="top" content={t.components.editor2.LevelSelect.view_external}>
         <AnchorButton
           minimal
           large
@@ -211,7 +210,7 @@ export const LevelSelect: FC<LevelSelectProps> = ({
           href={prtsMapUrl}
           disabled={!prtsMapUrl}
         />
-      </Tooltip2>
+      </Tooltip>
       {fetchError && (
         <span className="text-xs opacity-50">
           {t.components.editor2.LevelSelect.load_error({

--- a/src/components/editor2/action/ActionItem.tsx
+++ b/src/components/editor2/action/ActionItem.tsx
@@ -1,5 +1,4 @@
-import { Button, Callout, Card, Classes, Divider, Icon, InputGroup, MenuItem } from '@blueprintjs/core'
-import { Tooltip2 } from '@blueprintjs/popover2'
+import { Button, Callout, Card, Classes, Divider, Icon, InputGroup, MenuItem, Tooltip } from '@blueprintjs/core'
 
 import clsx from 'clsx'
 import { Draft } from 'immer'
@@ -139,9 +138,9 @@ export const ActionItem: FC<ActionItemProps> = memo(
                     action.type === CopilotDocV1.Type.BulletTime ? (
                       <>
                         <Divider className="grow rotate-12 ml-3" />
-                        <Tooltip2 placement="top" content={t.components.editor2.ActionItem.target_or_location}>
+                        <Tooltip placement="top" content={t.components.editor2.ActionItem.target_or_location}>
                           {t.components.editor2.ActionItem.or}
-                        </Tooltip2>
+                        </Tooltip>
                         <Divider className="grow rotate-12 mr-3" />
                       </>
                     ) : (
@@ -274,7 +273,7 @@ export const ActionItem: FC<ActionItemProps> = memo(
                         small
                         minimal
                         className={clsx(
-                          '!px-2.5 !bg-transparent [&_.bp4-icon]:!text-current',
+                          '!px-2.5 !bg-transparent [&_.bp6-icon]:!text-current',
                           action.direction === dir
                             ? '!text-inherit drop-shadow'
                             : '!text-gray-200 hover:!text-gray-400',

--- a/src/components/editor2/action/ActionLinker.tsx
+++ b/src/components/editor2/action/ActionLinker.tsx
@@ -1,5 +1,4 @@
-import { Button, Icon, Menu, MenuItem } from '@blueprintjs/core'
-import { Popover2, Tooltip2 } from '@blueprintjs/popover2'
+import { Button, Icon, Menu, MenuItem, PopoverNext, Tooltip } from '@blueprintjs/core'
 
 import clsx from 'clsx'
 import { Draft } from 'immer'
@@ -43,10 +42,11 @@ export const ActionLinker: FC<ActionLinkerProps> = ({ actionAtom, isDragging, is
             {t.components.editor2.ActionLinker.action}
           </Button>
         </CreateActionMenu>
-        <Popover2
-          minimal
+        <PopoverNext
+          animation="minimal"
+          arrow={false}
           placement="right-start"
-          popoverClassName="[&>.bp4-popover2-content]:!p-0 overflow-hidden"
+          popoverClassName="[&>.bp6-popover-content]:!p-0 overflow-hidden"
           content={
             <Menu>
               {(
@@ -77,9 +77,9 @@ export const ActionLinker: FC<ActionLinkerProps> = ({ actionAtom, isDragging, is
                     icon={icon}
                     text={title()}
                     labelElement={
-                      <Tooltip2 content={description()}>
+                      <Tooltip content={description()}>
                         <Icon className="!text-gray-300 dark:!text-gray-500" icon="info-sign" />
-                      </Tooltip2>
+                      </Tooltip>
                     }
                     onClick={() => {
                       if (index === 0 && conditionType === 'intermediatePreDelay') {
@@ -133,7 +133,7 @@ export const ActionLinker: FC<ActionLinkerProps> = ({ actionAtom, isDragging, is
           >
             {t.components.editor2.ActionLinker.condition}
           </Button>
-        </Popover2>
+        </PopoverNext>
       </div>
 
       <ConditionChain actionAtom={actionAtom} index={index} />
@@ -240,7 +240,7 @@ const ConditionNode: FC<ConditionNodeProps> = ({ title, unit, inputProps, index,
   title ??= typeInfo.title()
   return (
     <div className="flex items-baseline">
-      <Popover2
+      <PopoverNext
         placement="bottom"
         content={
           <Menu>
@@ -268,7 +268,7 @@ const ConditionNode: FC<ConditionNodeProps> = ({ title, unit, inputProps, index,
         <Button minimal className="!px-0 !py-1 min-h-0 !font-normal !text-inherit">
           {title}
         </Button>
-      </Popover2>
+      </PopoverNext>
       <NumericInput2
         intOnly
         buttonPosition="none"

--- a/src/components/editor2/action/CreateActionMenu.tsx
+++ b/src/components/editor2/action/CreateActionMenu.tsx
@@ -1,5 +1,14 @@
-import { Icon, Menu, MenuDivider, MenuItem, mergeRefs } from '@blueprintjs/core'
-import { Popover2, Popover2Props, PopperCustomModifer, Tooltip2 } from '@blueprintjs/popover2'
+import {
+  Icon,
+  Menu,
+  MenuDivider,
+  MenuItem,
+  PopoverNext,
+  PopoverNextProps,
+  PopoverNextRef,
+  Tooltip,
+  mergeRefs,
+} from '@blueprintjs/core'
 
 import { PrimitiveAtom, useSetAtom } from 'jotai'
 import { clamp } from 'lodash-es'
@@ -14,7 +23,7 @@ import { createAction } from '../reconciliation'
 interface CreateActionMenuProps {
   actionAtom?: PrimitiveAtom<EditorAction>
   renderTarget?: (
-    props: { locatorRef: Ref<HTMLElement> } & Parameters<NonNullable<Popover2Props['renderTarget']>>[0],
+    props: { locatorRef: Ref<HTMLElement> } & Parameters<NonNullable<PopoverNextProps['renderTarget']>>[0],
   ) => JSX.Element
   children?: ReactNode
 }
@@ -29,7 +38,7 @@ export const CreateActionMenu = forwardRef<CreateActionMenuRef, CreateActionMenu
     const dispatchActions = useSetAtom(editorAtoms.actionAtoms)
     const containerRef = useRef<HTMLElement>(null)
     const locatorRef = useRef<HTMLElement>(null)
-    const popperRef = useRef<Parameters<NonNullable<PopperCustomModifer['fn']>>[0]['instance']>()
+    const popoverRef = useRef<PopoverNextRef>(null)
     const [isOpen, setIsOpen] = useState(false)
     const t = useTranslation()
 
@@ -49,9 +58,9 @@ export const CreateActionMenu = forwardRef<CreateActionMenuRef, CreateActionMenu
           locator.style.left = `${left}px`
           setIsOpen((wasOpen) => {
             if (wasOpen) {
-              // 如果在 Popover 已经是打开状态时再次点击，会关闭并立刻再打开，而由于 Popover 内部的动画机制，
-              // 在关闭后 300ms 内打开会导致 Popper 不更新位置，所以这里必须手动更新
-              popperRef.current?.update()
+              // 已打开时再次点击会关闭并立刻重开，浮层动画期间位置不会自动跟随 locator，
+              // 所以这里手动让 Floating UI 重新计算位置
+              popoverRef.current?.reposition()
             }
             return true
           })
@@ -61,10 +70,12 @@ export const CreateActionMenu = forwardRef<CreateActionMenuRef, CreateActionMenu
     )
 
     return (
-      <Popover2
-        minimal
+      <PopoverNext
+        ref={popoverRef}
+        animation="minimal"
+        arrow={false}
         placement="right-start"
-        popoverClassName="[&>.bp4-popover2-content]:!p-0 overflow-hidden"
+        popoverClassName="[&>.bp6-popover-content]:!p-0 overflow-hidden"
         isOpen={isOpen}
         onInteraction={setIsOpen}
         content={
@@ -77,9 +88,9 @@ export const CreateActionMenu = forwardRef<CreateActionMenuRef, CreateActionMenu
                     icon={icon}
                     text={title()}
                     labelElement={
-                      <Tooltip2 content={description()}>
+                      <Tooltip content={description()}>
                         <Icon className="!text-gray-300 dark:!text-gray-500" icon="info-sign" />
-                      </Tooltip2>
+                      </Tooltip>
                     }
                     onClick={() => {
                       edit(() => {
@@ -101,18 +112,6 @@ export const CreateActionMenu = forwardRef<CreateActionMenuRef, CreateActionMenu
             ).flat()}
           </Menu>
         }
-        modifiersCustom={
-          renderTarget
-            ? [
-                {
-                  name: 'getPopperInstance',
-                  enabled: true,
-                  phase: 'main',
-                  fn: ({ instance }) => void (popperRef.current = instance),
-                },
-              ]
-            : undefined
-        }
         renderTarget={
           renderTarget &&
           (({ ref, ...props }) =>
@@ -124,7 +123,7 @@ export const CreateActionMenu = forwardRef<CreateActionMenuRef, CreateActionMenu
         }
       >
         {children}
-      </Popover2>
+      </PopoverNext>
     )
   },
 )

--- a/src/components/editor2/action/LevelMap.tsx
+++ b/src/components/editor2/action/LevelMap.tsx
@@ -151,7 +151,7 @@ export const LevelMap: FC<LevelMapProps> = memo(({ className }) => {
         <NonIdealState
           className="absolute inset-0"
           icon={
-            mapStatus === 'loading' ? <Spinner className="[&_.bp4-spinner-head]:stroke-current" /> : 'area-of-interest'
+            mapStatus === 'loading' ? <Spinner className="[&_.bp6-spinner-head]:stroke-current" /> : 'area-of-interest'
           }
           description={mapStatus === 'idle' ? t.components.editor2.LevelMap.select_level : undefined}
         />

--- a/src/components/editor2/operator/GroupItem.tsx
+++ b/src/components/editor2/operator/GroupItem.tsx
@@ -1,5 +1,4 @@
-import { Button, Callout, Card, Classes, Dialog, Icon, Menu, MenuItem } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
+import { Button, Callout, Card, Classes, Dialog, Icon, Menu, MenuItem, PopoverNext } from '@blueprintjs/core'
 import { SortableContext } from '@dnd-kit/sortable'
 
 import clsx from 'clsx'
@@ -75,7 +74,7 @@ export const GroupItem: FC<GroupItemProps> = memo(({ baseGroupAtom }) => {
     >
       <div className="flex">
         <GroupTitle baseGroupAtom={baseGroupAtom} />
-        <Popover2
+        <PopoverNext
           placement="bottom"
           content={
             <Menu>
@@ -137,7 +136,7 @@ export const GroupItem: FC<GroupItemProps> = memo(({ baseGroupAtom }) => {
           }
         >
           <Button minimal icon={<Icon icon="more" className="rotate-90" />} className="h-full !p-0 !border-0" />
-        </Popover2>
+        </PopoverNext>
       </div>
       {errors && (
         <Callout icon={null} intent="danger" className="!p-2 !rounded-none text-xs">
@@ -398,7 +397,6 @@ const GroupTitle = memo(({ baseGroupAtom }: GroupItemProps) => {
         inputProps={{
           inputClassName:
             '!p-4 !pr-0 !border-0 hover:bg-gray-100 focus:bg-gray-100 dark:hover:bg-gray-600 dark:focus:bg-gray-600 !shadow-none font-bold text-gray-800',
-          size: 10,
           placeholder: t.components.editor2.GroupItem.group_name + '*',
           inputRef: titleInputRef,
         }}

--- a/src/components/editor2/operator/OperatorItem.tsx
+++ b/src/components/editor2/operator/OperatorItem.tsx
@@ -1,5 +1,4 @@
-import { Button, Card, Classes, Icon, Menu, MenuItem } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
+import { Button, Card, Classes, Icon, Menu, MenuItem, PopoverNext } from '@blueprintjs/core'
 
 import clsx from 'clsx'
 import { useAtom, useSetAtom } from 'jotai'
@@ -60,7 +59,7 @@ export const OperatorItem: FC<OperatorItemProps> = memo(
     return (
       <div className={clsx('relative flex items-start', isDragging && 'invisible')}>
         <div className="relative">
-          <Popover2
+          <PopoverNext
             placement="top"
             content={
               <Menu>
@@ -108,7 +107,7 @@ export const OperatorItem: FC<OperatorItemProps> = memo(
                 />
               )}
             </Card>
-          </Popover2>
+          </PopoverNext>
 
           {info?.prof !== 'TOKEN' && (
             <>
@@ -453,7 +452,7 @@ export const OperatorItem: FC<OperatorItemProps> = memo(
               }}
               popoverProps={{
                 placement: 'top',
-                popoverClassName: '!rounded-none [&_.bp4-popover2-content]:!p-0 [&_.bp4-menu]:min-w-0 [&_li]:!mb-0',
+                popoverClassName: '!rounded-none [&_.bp6-popover-content]:!p-0 [&_.bp6-menu]:min-w-0 [&_li]:!mb-0',
               }}
             >
               <Button

--- a/src/components/editor2/operator/sheet/SheetList.tsx
+++ b/src/components/editor2/operator/sheet/SheetList.tsx
@@ -1,5 +1,4 @@
-import { Button } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
+import { Button, PopoverNext } from '@blueprintjs/core'
 
 import { FC, useCallback, useEffect, useRef } from 'react'
 
@@ -66,7 +65,7 @@ export const SheetList: FC<SheetListProps> = () => {
           )}
         </div>
         <div className="h-full sticky top-0 self-start shrink-0 z-10 flex flex-col items-center justify-center">
-          <Popover2
+          <PopoverNext
             content={
               <>
                 <OperatorRaritySelect />
@@ -74,7 +73,7 @@ export const SheetList: FC<SheetListProps> = () => {
             }
           >
             <Button minimal icon="filter-list" />
-          </Popover2>
+          </PopoverNext>
           <OperatorMutipleSelect />
           <OperatorBackToTop {...{ toTop }} />
         </div>

--- a/src/components/editor2/source/SourceEditor.tsx
+++ b/src/components/editor2/source/SourceEditor.tsx
@@ -86,7 +86,7 @@ const SourceEditor = withSuspensable(({ onUnsavedChanges }: SourceEditorProps) =
           intent={hasUnsavedChanges ? 'primary' : 'success'}
           icon={
             pending ? (
-              <Spinner size={IconSize.STANDARD} className="bp4-icon" />
+              <Spinner size={IconSize.STANDARD} className="bp6-icon" />
             ) : hasUnsavedChanges ? (
               'warning-sign'
             ) : (

--- a/src/components/entity/EDifficulty.tsx
+++ b/src/components/entity/EDifficulty.tsx
@@ -1,5 +1,4 @@
-import { Tag } from '@blueprintjs/core'
-import { Tooltip2 } from '@blueprintjs/popover2'
+import { Tag, Tooltip } from '@blueprintjs/core'
 
 import clsx from 'clsx'
 import { FC, ReactNode } from 'react'
@@ -14,7 +13,7 @@ const DifficultyTag: FC<{
   hardLevel?: boolean
 }> = ({ tooltip, content, hardLevel }) => {
   return (
-    <Tooltip2 placement="bottom" content={<div className="max-w-sm">{tooltip}</div>}>
+    <Tooltip placement="bottom" content={<div className="max-w-sm">{tooltip}</div>}>
       <Tag
         className={clsx(
           'transition border border-solid !text-xs cursor-help tracking-tight !px-2 !py-1 !mx-1 !my-1 leading-none !min-h-0',
@@ -25,7 +24,7 @@ const DifficultyTag: FC<{
       >
         {content}
       </Tag>
-    </Tooltip2>
+    </Tooltip>
   )
 }
 

--- a/src/components/operation-set/AddToOperationSet.tsx
+++ b/src/components/operation-set/AddToOperationSet.tsx
@@ -170,7 +170,7 @@ function AddToOperationSet({ operationIds, onSuccess }: AddToOperationSetProps) 
             <div key={id}>
               <Checkbox
                 className={clsx(
-                  'flex items-center m-0 p-2 !pl-10 hover:bg-slate-200 dark:hover:bg-slate-800 [&>.bp4-control-indicator]:mt-0',
+                  'flex items-center m-0 p-2 !pl-10 hover:bg-slate-200 dark:hover:bg-slate-800 [&>.bp6-control-indicator]:mt-0',
                   checkboxOverrides[id] !== undefined && checkboxOverrides[id] !== defaultChecked(id) && 'font-bold',
                 )}
                 checked={checkboxOverrides[id] ?? defaultChecked(id)}

--- a/src/components/operation-set/OperationSetEditor.tsx
+++ b/src/components/operation-set/OperationSetEditor.tsx
@@ -10,8 +10,8 @@ import {
   MenuItem,
   NonIdealState,
   TextArea,
+  PopoverNext,
 } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors } from '@dnd-kit/core'
 import { SortableContext, arrayMove, verticalListSortingStrategy } from '@dnd-kit/sortable'
 
@@ -387,8 +387,9 @@ function OperationSelector({ operationSet, selectorRef }: OperationSelectorProps
   return (
     <div>
       <div className="mb-2 flex">
-        <Popover2
-          minimal
+        <PopoverNext
+          animation="minimal"
+          arrow={false}
           captureDismiss
           placement="bottom-start"
           content={
@@ -420,7 +421,7 @@ function OperationSelector({ operationSet, selectorRef }: OperationSelectorProps
           }
         >
           <Button small minimal icon="sort" text={t.components.operationSet.OperationSetEditor.quick_sort + '...'} />
-        </Popover2>
+        </PopoverNext>
         <Button
           small
           minimal

--- a/src/components/uploader/OperationUploader.tsx
+++ b/src/components/uploader/OperationUploader.tsx
@@ -1,5 +1,15 @@
-import { AnchorButton, Callout, FileInput, FormGroup, H4, Icon, Spinner, SpinnerSize, Tag } from '@blueprintjs/core'
-import { Tooltip2 } from '@blueprintjs/popover2'
+import {
+  AnchorButton,
+  Callout,
+  FileInput,
+  FormGroup,
+  H4,
+  Icon,
+  Spinner,
+  SpinnerSize,
+  Tag,
+  Tooltip,
+} from '@blueprintjs/core'
 
 import { useLevels } from 'apis/level'
 import { createOperation } from 'apis/operation'
@@ -176,7 +186,7 @@ export const OperationUploader: ComponentType = withSuspensable(() => {
           />
         </FormGroup>
 
-        <Tooltip2 fill className="mt-4" placement="top" disabled={!nonUploadableReason} content={nonUploadableReason}>
+        <Tooltip fill className="mt-4" placement="top" disabled={!nonUploadableReason} content={nonUploadableReason}>
           {(() => {
             const settledCount = files.filter((file) => file.uploaded || file.error).length
 
@@ -199,7 +209,7 @@ export const OperationUploader: ComponentType = withSuspensable(() => {
               </AnchorButton>
             )
           })()}
-        </Tooltip2>
+        </Tooltip>
 
         {globalErrors && (
           <Callout className="mt-4" intent="danger" icon="error" title={t.components.uploader.OperationUploader.error}>

--- a/src/components/viewer/OperationRating.tsx
+++ b/src/components/viewer/OperationRating.tsx
@@ -1,5 +1,4 @@
-import { Icon, IconSize } from '@blueprintjs/core'
-import { Popover2InteractionKind, Tooltip2 } from '@blueprintjs/popover2'
+import { Icon, IconSize, PopoverInteractionKind, Tooltip } from '@blueprintjs/core'
 
 import clsx from 'clsx'
 import { FC } from 'react'
@@ -27,9 +26,9 @@ const GetLevelDescription: FC<{
       <span>{t.components.viewer.OperationRating.not_enough_ratings_short}</span>
     )
   ) : (
-    <Tooltip2
+    <Tooltip
       className="!inline-block !mt-0"
-      interactionKind={Popover2InteractionKind.HOVER}
+      interactionKind={PopoverInteractionKind.HOVER}
       content={t.components.viewer.OperationRating.liked_percentage({
         percent: likePercent,
         ratio: likeRatio,
@@ -37,7 +36,7 @@ const GetLevelDescription: FC<{
       position="bottom-left"
     >
       {ratingLevelToString(operation.ratingLevel)}
-    </Tooltip2>
+    </Tooltip>
   )
 }
 

--- a/src/components/viewer/OperationRating.tsx
+++ b/src/components/viewer/OperationRating.tsx
@@ -33,7 +33,7 @@ const GetLevelDescription: FC<{
         percent: likePercent,
         ratio: likeRatio,
       })}
-      position="bottom-left"
+      placement="bottom-start"
     >
       {ratingLevelToString(operation.ratingLevel)}
     </Tooltip>

--- a/src/components/viewer/OperationSetViewer.tsx
+++ b/src/components/viewer/OperationSetViewer.tsx
@@ -1,5 +1,4 @@
-import { Alert, Button, H3, H4, H5, Icon, Menu, MenuItem, NonIdealState } from '@blueprintjs/core'
-import { Popover2 } from '@blueprintjs/popover2'
+import { Alert, Button, H3, H4, H5, Icon, Menu, MenuItem, NonIdealState, PopoverNext } from '@blueprintjs/core'
 import { ErrorBoundary } from '@sentry/react'
 
 import { deleteOperationSet, useOperationSet, useRefreshOperationSets } from 'apis/operation-set'
@@ -148,14 +147,14 @@ export const OperationSetViewer: ComponentType<{
             <div className="flex-1" />
 
             {operationSet.creatorId === auth.userId && (
-              <Popover2 content={<ManageMenu operationSet={operationSet} onUpdate={() => onCloseDrawer()} />}>
+              <PopoverNext content={<ManageMenu operationSet={operationSet} onUpdate={() => onCloseDrawer()} />}>
                 <Button
                   className="ml-4"
                   icon="wrench"
                   text={t.components.viewer.OperationSetViewer.manage}
                   rightIcon="caret-down"
                 />
-              </Popover2>
+              </PopoverNext>
             )}
 
             <Button

--- a/src/components/viewer/OperationViewer.tsx
+++ b/src/components/viewer/OperationViewer.tsx
@@ -15,8 +15,9 @@ import {
   NonIdealState,
   Switch,
   Tag,
+  PopoverNext,
+  Tooltip,
 } from '@blueprintjs/core'
-import { Popover2, Tooltip2 } from '@blueprintjs/popover2'
 import { ErrorBoundary } from '@sentry/react'
 
 import { banComments, deleteOperation, rateOperation, useOperation, useRefreshOperations } from 'apis/operation'
@@ -304,7 +305,7 @@ export const OperationViewer: ComponentType<{
 
             <div className="flex flex-wrap items-center gap-2 md:gap-4">
               {operation.uploaderId === auth.userId && (
-                <Popover2
+                <PopoverNext
                   content={
                     <ManageMenu
                       operation={operation}
@@ -314,7 +315,7 @@ export const OperationViewer: ComponentType<{
                   }
                 >
                   <Button icon="wrench" text={t.components.viewer.OperationViewer.manage} rightIcon="caret-down" />
-                </Popover2>
+                </PopoverNext>
               )}
 
               <Button
@@ -490,7 +491,7 @@ function OperationViewerInner({
             <OperationRating operation={operation} className="mr-2" />
 
             <ButtonGroup className="flex items-center ml-2">
-              <Tooltip2 content="o(*≧▽≦)ツ" placement="bottom">
+              <Tooltip content="o(*≧▽≦)ツ" placement="bottom">
                 <Button
                   icon="thumbs-up"
                   intent={operation.ratingType === OpRatingType.Like ? 'success' : 'none'}
@@ -498,15 +499,15 @@ function OperationViewerInner({
                   active={operation.ratingType === OpRatingType.Like}
                   onClick={() => handleRating(OpRatingType.Like)}
                 />
-              </Tooltip2>
-              <Tooltip2 content=" ヽ(。>д<)ｐ" placement="bottom">
+              </Tooltip>
+              <Tooltip content=" ヽ(。>д<)ｐ" placement="bottom">
                 <Button
                   icon="thumbs-down"
                   intent={operation.ratingType === OpRatingType.Dislike ? 'danger' : 'none'}
                   active={operation.ratingType === OpRatingType.Dislike}
                   onClick={() => handleRating(OpRatingType.Dislike)}
                 />
-              </Tooltip2>
+              </Tooltip>
             </ButtonGroup>
           </FactItem>
         </div>

--- a/src/components/viewer/comment/CommentArea.tsx
+++ b/src/components/viewer/comment/CommentArea.tsx
@@ -316,7 +316,7 @@ const CommentRatingButtons = ({ comment }: { comment: CommentInfo }) => {
       <Button
         minimal
         small
-        className="[&_.bp4-button-text]:-ml-0.5 "
+        className="[&_.bp6-button-text]:-ml-0.5 "
         icon={<OutlinedIcon icon="thumbs-up" size={14} />}
         onClick={() => rate(CommentRating.Like)}
       >

--- a/src/components/viewer/comment/CommentForm.tsx
+++ b/src/components/viewer/comment/CommentForm.tsx
@@ -86,7 +86,7 @@ export const CommentForm = ({
       <TextArea
         fill
         rows={2}
-        growVertically
+        autoResize
         large
         maxLength={maxLength}
         placeholder={placeholder || defaultPlaceholder}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -28,13 +28,13 @@ export const THEME_CONFIG: ThemeDefinition[] = [
     id: 'dark',
     i18nKey: 'dark',
     icon: 'moon',
-    classList: ['bp4-dark', 'dark'],
+    classList: ['bp6-dark', 'dark'],
   },
   {
     id: 'high-contrast',
     i18nKey: 'highContrast',
     icon: 'contrast',
-    classList: ['bp4-dark', 'dark', 'high-contrast-theme'],
+    classList: ['bp6-dark', 'dark', 'high-contrast-theme'],
   },
 ]
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import '@blueprintjs/core/lib/css/blueprint.css'
 import '@blueprintjs/icons/lib/css/blueprint-icons.css'
-import '@blueprintjs/popover2/lib/css/blueprint-popover2.css'
 import '@blueprintjs/select/lib/css/blueprint-select.css'
+import { Icons } from '@blueprintjs/icons'
 import * as Sentry from '@sentry/react'
 import { BrowserTracing } from '@sentry/tracing'
 
@@ -50,6 +50,11 @@ if (navigator.userAgent.includes('Win')) {
 }
 
 clearOutdatedSwrCache()
+
+// v6 起 Blueprint 图标改为按需异步加载（dynamic import）。
+// 这里一次性加载全部图标，避免组件首次渲染时图标闪烁/缺失，等价于 v4 的全量行为。
+Icons.setLoaderOptions({ loader: 'all' })
+void Icons.loadAll()
 
 const CreatePageLazy = withSuspensable(lazy(() => import('./pages/create').then((m) => ({ default: m.CreatePage }))))
 const EditorPageLazy = withSuspensable(lazy(() => import('./pages/editor').then((m) => ({ default: m.EditorPage }))))

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -51,8 +51,9 @@ if (navigator.userAgent.includes('Win')) {
 
 clearOutdatedSwrCache()
 
-// v6 起 Blueprint 图标改为按需异步加载（dynamic import）。
-// 这里一次性加载全部图标，避免组件首次渲染时图标闪烁/缺失，等价于 v4 的全量行为。
+// v6 起 Blueprint 图标改为按需异步加载（dynamic import）。这里改用 'all' loader 并尽早
+// 触发一次性全量加载，尽量缩短图标缺失窗口。注意：与 v4 的同步内联不同，加载仍是异步的，
+// 首帧若早于图标 chunk 到达，可能短暂渲染空图标——这是 v6 的设计取舍，此处不阻塞首帧。
 Icons.setLoaderOptions({ loader: 'all' })
 void Icons.loadAll()
 

--- a/src/pages/create.tsx
+++ b/src/pages/create.tsx
@@ -1,5 +1,4 @@
-import { Button, Checkbox } from '@blueprintjs/core'
-import { Tooltip2 } from '@blueprintjs/popover2'
+import { Button, Checkbox, Tooltip } from '@blueprintjs/core'
 
 import { isEqual } from 'lodash-es'
 import { CopilotSetStatus } from 'maa-copilot-client'
@@ -173,7 +172,7 @@ export const CreatePage: ComponentType = withGlobalErrorBoundary(
             />
             <div className="flex-[100%_0_0]" />
             <div className="ml-auto mt-2">
-              <Tooltip2
+              <Tooltip
                 placement="bottom"
                 content={
                   <>
@@ -192,7 +191,7 @@ export const CreatePage: ComponentType = withGlobalErrorBoundary(
                 >
                   <span className="-ml-1 opacity-75">{t.pages.create.public}</span>
                 </Checkbox>
-              </Tooltip2>
+              </Tooltip>
             </div>
           </>
         }

--- a/src/styles/blueprint.less
+++ b/src/styles/blueprint.less
@@ -8,11 +8,11 @@
 
 // 加上最外层的id，保证自定义css优先级
 body {
-  .bp4-card {
+  .bp6-card {
     @apply rounded-lg py-4;
   }
 
-  .bp4-input {
+  .bp6-input {
     @apply block w-full py-2 pl-3 pr-3;
     @apply bg-white shadow-sm border border-slate-400 rounded-md border-solid;
     @apply focus:border-violet-500;
@@ -26,36 +26,36 @@ body {
     }
   }
 
-  .bp4-input,
+  .bp6-input,
   // class of TagInput (also used by MultiSelect2)
-  .bp4-input-ghost {
+  .bp6-input-ghost {
     @apply placeholder:italic placeholder:text-slate-400;
   }
 
   // simulate border using outline because Blueprint TextArea's auto-sizing doesn't work well with border
-  textarea.bp4-input {
+  textarea.bp6-input {
     @apply border-none outline outline-1 outline-slate-400;
 
     outline-offset: -1px;
   }
 
-  .bp4-file-upload-input {
+  .bp6-file-upload-input {
     @apply placeholder:italic placeholder:text-slate-400;
     @apply block w-full;
     @apply bg-white shadow-sm border border-slate-400 rounded-md border-solid;
     @apply focus:border-violet-500;
   }
 
-  .bp4-large .bp4-file-upload-input::after {
+  .bp6-large .bp6-file-upload-input::after {
     @apply m-1;
   }
 
-  .bp4-callout {
+  .bp6-callout {
     @apply rounded-md;
   }
 
-  .bp4-input-group {
-    .bp4-icon {
+  .bp6-input-group {
+    .bp6-icon {
       @apply absolute inset-y-0 left-0 flex items-center m-0;
 
       span {
@@ -63,20 +63,20 @@ body {
       }
     }
 
-    .bp4-button .bp4-icon {
+    .bp6-button .bp6-icon {
       @apply relative;
     }
 
-    .bp4-icon + .bp4-input {
+    .bp6-icon + .bp6-input {
       @apply pl-8;
     }
   }
 
-  .bp4-large .bp4-file-upload-input {
+  .bp6-large .bp6-file-upload-input {
     line-height: 2.375rem;
   }
 
-  .bp4-large .bp4-file-upload-input::after {
+  .bp6-large .bp6-file-upload-input::after {
     @apply text-slate-900 shadow-none rounded-none m-0;
     @apply border-l border-solid border-slate-400;
     @apply hover:shadow-none;
@@ -85,74 +85,74 @@ body {
     line-height: 2.375rem;
   }
 
-  .bp4-button {
+  .bp6-button {
     @apply flex;
     @apply border border-solid border-transparent rounded-md font-semibold;
     @apply text-sm;
     @apply transition-colors;
     @apply justify-center items-center;
 
-    &:not(.bp4-small) {
+    &:not(.bp6-small) {
       @apply py-2 px-4;
     }
 
-    &:not([class*='bp4-intent-']):not(.bp4-minimal) {
+    &:not([class*='bp6-intent-']):not(.bp6-minimal) {
       @apply text-slate-900 shadow-none;
       @apply border-slate-400;
       @apply hover:shadow-none;
     }
 
-    &.bp4-disabled {
+    &.bp6-disabled {
       @apply opacity-50;
     }
 
-    &.bp4-intent-primary {
+    &.bp6-intent-primary {
       &,
-      &.bp4-disabled {
+      &.bp6-disabled {
         @apply bg-violet-500 enabled:hover:bg-violet-600;
       }
-      &.bp4-minimal {
+      &.bp6-minimal {
         @apply bg-transparent enabled:hover:bg-violet-100;
       }
     }
 
-    &.bp4-intent-success {
+    &.bp6-intent-success {
       &,
-      &.bp4-disabled {
+      &.bp6-disabled {
         @apply bg-emerald-500 enabled:hover:bg-emerald-600;
       }
-      &.bp4-minimal {
+      &.bp6-minimal {
         @apply bg-transparent enabled:hover:bg-emerald-100;
       }
     }
 
-    &.bp4-intent-warning {
+    &.bp6-intent-warning {
       &,
-      &.bp4-disabled {
+      &.bp6-disabled {
         @apply bg-amber-500 enabled:hover:bg-amber-600;
       }
-      &.bp4-minimal {
+      &.bp6-minimal {
         @apply bg-transparent enabled:hover:bg-amber-100;
       }
     }
 
-    &.bp4-intent-danger {
+    &.bp6-intent-danger {
       &,
-      &.bp4-disabled {
+      &.bp6-disabled {
         @apply bg-red-500 enabled:hover:bg-red-600;
       }
-      &.bp4-minimal {
+      &.bp6-minimal {
         @apply bg-transparent enabled:hover:bg-red-100;
       }
     }
 
-    .bp4-icon:first-child {
+    .bp6-icon:first-child {
       @apply mr-2;
     }
   }
 
   // TODO: 请把select换成组件库的select
-  // .bp4-html-select select {
+  // .bp6-html-select select {
   //   @apply block py-2 px-4;
   //   @apply border border-solid border-slate-400 rounded-md font-semibold;
   //   @apply text-sm shadow-none text-center;
@@ -160,13 +160,13 @@ body {
   //   @apply focus:outline-none;
   // }
 
-  .bp4-popover2 {
+  .bp6-popover {
     @apply rounded-lg;
-    .bp4-popover2-content {
+    .bp6-popover-content {
       @apply rounded-lg p-2;
     }
     ul li {
-      .bp4-menu-item {
+      .bp6-menu-item {
         @apply rounded-md;
       }
 
@@ -176,44 +176,44 @@ body {
     }
   }
 
-  .bp4-dialog {
+  .bp6-dialog {
     @apply rounded-lg;
-    & .bp4-dialog-header {
+    & .bp6-dialog-header {
       @apply rounded-t-lg;
     }
   }
 
-  .bp4-popover2 .bp4-heading {
+  .bp6-popover .bp6-heading {
     @apply opacity-80;
   }
 
-  .bp4-toast {
+  .bp6-toast {
     @apply rounded border-none;
-    &.bp4-intent-success {
+    &.bp6-intent-success {
       @apply bg-emerald-500;
-      .bp4-button {
+      .bp6-button {
         @apply !bg-emerald-500;
       }
     }
-    &.bp4-intent-warning {
+    &.bp6-intent-warning {
       @apply bg-amber-500;
-      .bp4-button {
+      .bp6-button {
         @apply !bg-amber-500;
       }
     }
-    &.bp4-intent-danger {
+    &.bp6-intent-danger {
       @apply bg-red-500;
-      .bp4-button {
+      .bp6-button {
         @apply !bg-red-500;
       }
     }
-    .bp4-button {
+    .bp6-button {
       @apply border-none p-0;
     }
   }
 
-  .bp4-numeric-input {
-    & .bp4-input-group {
+  .bp6-numeric-input {
+    & .bp6-input-group {
       @apply !mr-0;
 
       & input {
@@ -221,7 +221,7 @@ body {
       }
     }
 
-    & .bp4-button-group {
+    & .bp6-button-group {
       & button {
         @apply !rounded-l-none;
       }
@@ -234,16 +234,16 @@ body {
     }
   }
 
-  .bp4-skeleton {
+  .bp6-skeleton {
     @apply rounded-md;
   }
 
-  label.bp4-checkbox {
+  label.bp6-checkbox {
     @apply select-none;
   }
 }
 
-.bp4-dark {
+.bp6-dark {
   @dark-content-bg: #2f343c;
 
   // background
@@ -253,9 +253,9 @@ body {
   }
 
   // navbar
-  .bp4-navbar {
+  .bp6-navbar {
     a,
-    .bp4-tag span {
+    .bp6-tag span {
       @apply text-slate-50;
     }
   }
@@ -272,8 +272,8 @@ body {
   }
 
   // 作业详情页
-  .bp4-card p,
-  .bp4-card div,
+  .bp6-card p,
+  .bp6-card div,
   .markdown-body,
   .markdown-body blockquote,
   .markdown-body span {
@@ -285,33 +285,33 @@ body {
   }
 
   // 通用样式 - 按钮、tag、提示
-  .bp4-button {
-    .bp4-button-text {
+  .bp6-button {
+    .bp6-button-text {
       @apply text-slate-50;
     }
 
-    &.bp4-minimal.bp4-intent-danger:hover:enabled {
+    &.bp6-minimal.bp6-intent-danger:hover:enabled {
       @apply bg-red-500;
     }
   }
 
-  .bp4-tag {
+  .bp6-tag {
     @apply bg-slate-900 text-slate-200;
 
-    &.bp4-intent-danger {
+    &.bp6-intent-danger {
       @apply bg-red-500;
     }
 
-    &.bp4-intent-primary {
+    &.bp6-intent-primary {
       @apply bg-blue-500;
     }
   }
 
-  .bp4-callout p {
+  .bp6-callout p {
     @apply text-slate-50;
   }
 
-  .bp4-label {
+  .bp6-label {
     p,
     span,
     div {
@@ -319,27 +319,27 @@ body {
     }
   }
 
-  .bp4-text-muted {
+  .bp6-text-muted {
     @apply text-slate-100;
   }
 
-  .bp4-menu {
-    .bp4-menu-item.bp4-selected {
+  .bp6-menu {
+    .bp6-menu-item.bp6-selected {
       @apply text-slate-100;
     }
   }
 
-  .bp4-form-group {
-    .bp4-form-helper-text {
+  .bp6-form-group {
+    .bp6-form-helper-text {
       @apply text-slate-100;
     }
 
-    .bp4-input-group input {
+    .bp6-input-group input {
       @apply text-slate-100;
     }
   }
 
-  .bp4-tabs {
+  .bp6-tabs {
     div,
     span,
     p {
@@ -348,7 +348,7 @@ body {
   }
 }
 
-body.bp4-dark.high-contrast-theme {
+body.bp6-dark.high-contrast-theme {
   @hc-dark-bg: #232326;
   @hc-dark-border: #38383b;
   @hc-input-bg: #2d2d30;
@@ -360,30 +360,30 @@ body.bp4-dark.high-contrast-theme {
   }
 
   // navbar
-  .bp4-navbar {
+  .bp6-navbar {
     background-color: @hc-dark-bg;
     border-bottom: 1px solid @hc-dark-border;
 
     a,
-    .bp4-tag span {
+    .bp6-tag span {
       @apply text-slate-50;
     }
   }
 
-  .bp4-dialog,
-  .bp4-drawer,
-  .bp4-menu {
+  .bp6-dialog,
+  .bp6-drawer,
+  .bp6-menu {
     background-color: @hc-dark-bg;
     border: 1px solid @hc-dark-border;
     color: @hc-text-color;
   }
 
-  .bp4-card {
+  .bp6-card {
     background-color: @hc-dark-bg;
     color: @hc-text-color;
   }
 
-  .bp4-drawer {
+  .bp6-drawer {
     .bg-slate-100,
     .dark\:bg-slate-900 {
       background-color: @hc-dark-bg !important;
@@ -393,29 +393,29 @@ body.bp4-dark.high-contrast-theme {
     }
   }
 
-  .bp4-popover2 .bp4-popover2-content,
-  .bp4-popover2.bp4-dark .bp4-popover2-content {
+  .bp6-popover .bp6-popover-content,
+  .bp6-popover.bp6-dark .bp6-popover-content {
     background-color: @hc-dark-bg !important;
     border: 1px solid @hc-dark-border !important;
     color: @hc-text-color !important;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5) !important;
   }
 
-  .bp4-popover2 .bp4-popover2-arrow-fill {
+  .bp6-popover .bp6-popover-arrow-fill {
     fill: @hc-dark-bg !important;
   }
-  .bp4-popover2 .bp4-popover2-arrow-border {
+  .bp6-popover .bp6-popover-arrow-border {
     fill: @hc-dark-border !important;
   }
 
-  .bp4-popover2-content {
-    .bp4-menu {
+  .bp6-popover-content {
+    .bp6-menu {
       background-color: transparent;
       border: none;
     }
 
-    .bp4-input-group {
-      .bp4-input {
+    .bp6-input-group {
+      .bp6-input {
         background-color: @hc-input-bg;
         border: 1px solid @hc-dark-border;
         color: #ffffff;
@@ -430,24 +430,24 @@ body.bp4-dark.high-contrast-theme {
         }
       }
 
-      .bp4-icon {
+      .bp6-icon {
         color: #9ca3af;
         background-color: transparent;
       }
     }
   }
 
-  .bp4-input,
+  .bp6-input,
   textarea,
-  .bp4-file-upload-input {
+  .bp6-file-upload-input {
     background-color: @hc-input-bg;
     border-color: @hc-dark-border;
     color: #fff;
   }
 
   // 作业详情页
-  .bp4-card p,
-  .bp4-card div,
+  .bp6-card p,
+  .bp6-card div,
   .markdown-body,
   .markdown-body blockquote,
   .markdown-body span {
@@ -465,8 +465,8 @@ body.bp4-dark.high-contrast-theme {
   }
 
   // 按钮
-  .bp4-button {
-    &:not([class*='bp4-intent-']):not(.bp4-minimal) {
+  .bp6-button {
+    &:not([class*='bp6-intent-']):not(.bp6-minimal) {
       background-color: @hc-input-bg;
       border-color: @hc-dark-border;
 
@@ -475,15 +475,15 @@ body.bp4-dark.high-contrast-theme {
       }
     }
 
-    .bp4-button-text {
+    .bp6-button-text {
       @apply text-slate-50;
     }
   }
 
-  .bp4-button.bp4-minimal.bp4-active.\!text-inherit {
+  .bp6-button.bp6-minimal.bp6-active.\!text-inherit {
     color: rgb(3 105 161 / var(--tw-bg-opacity)) !important;
 
-    .bp4-icon,
+    .bp6-icon,
     svg {
       fill: currentColor !important;
       color: inherit !important;
@@ -491,19 +491,19 @@ body.bp4-dark.high-contrast-theme {
   }
 
   // Tag
-  .bp4-tag {
+  .bp6-tag {
     background-color: #333 !important;
     border: 1px solid #444 !important;
     color: @hc-text-color !important;
 
-    &.bp4-intent-danger,
+    &.bp6-intent-danger,
     &.bg-red-400 {
       background-color: #4a1e1e !important;
       border-color: #7f1d1d !important;
       color: #fca5a5 !important;
     }
 
-    &.bp4-intent-primary,
+    &.bp6-intent-primary,
     &.bg-violet-400 {
       background-color: #4c1d95 !important;
       border-color: #6d28d9 !important;
@@ -515,8 +515,8 @@ body.bp4-dark.high-contrast-theme {
     }
   }
 
-  .bp4-tooltip2 {
-    .bp4-popover2-content {
+  .bp6-tooltip2 {
+    .bp6-popover-content {
       background-color: @hc-dark-bg !important;
       border: 1px solid @hc-dark-border !important;
       color: @hc-text-color !important;
@@ -527,16 +527,16 @@ body.bp4-dark.high-contrast-theme {
       }
     }
 
-    .bp4-popover2-arrow-fill {
+    .bp6-popover-arrow-fill {
       fill: @hc-dark-bg !important;
     }
-    .bp4-popover2-arrow-border {
+    .bp6-popover-arrow-border {
       fill: @hc-dark-border !important;
     }
   }
 
-  .bp4-menu {
-    .bp4-menu-item.bp4-selected {
+  .bp6-menu {
+    .bp6-menu-item.bp6-selected {
       @apply text-slate-100;
       background-color: rgba(139, 92, 246, 0.15) !important;
     }
@@ -569,25 +569,25 @@ body.bp4-dark.high-contrast-theme {
     border-bottom: 1px solid @hc-dark-border !important;
   }
 
-  .bp4-file-upload-input {
+  .bp6-file-upload-input {
     box-shadow: inset 0 0 0 1px @hc-dark-border !important;
     background-color: @hc-input-bg !important;
     color: @hc-text-color !important;
   }
 
-  .bp4-file-upload-input::after {
+  .bp6-file-upload-input::after {
     background-color: @hc-input-bg !important;
     border-left: 1px solid @hc-dark-border !important;
     color: @hc-text-color !important;
     box-shadow: none !important;
   }
-  .bp4-file-input:hover .bp4-file-upload-input::after {
+  .bp6-file-input:hover .bp6-file-upload-input::after {
     background-color: #3e3e42 !important;
   }
 
-  .bp4-input,
-  textarea.bp4-input,
-  input.bp4-input {
+  .bp6-input,
+  textarea.bp6-input,
+  input.bp6-input {
     background-color: @hc-input-bg !important;
     box-shadow: inset 0 0 0 1px @hc-dark-border !important;
     color: #ffffff !important;
@@ -595,17 +595,17 @@ body.bp4-dark.high-contrast-theme {
       color: #6b7280 !important;
     }
     &:disabled,
-    &.bp4-disabled {
+    &.bp6-disabled {
       background-color: #202023 !important;
       box-shadow: none !important;
       color: #71717a !important;
     }
   }
 
-  .bp4-input:focus,
-  .bp4-input.bp4-active,
-  textarea.bp4-input:focus,
-  textarea.bp4-input.bp4-active {
+  .bp6-input:focus,
+  .bp6-input.bp6-active,
+  textarea.bp6-input:focus,
+  textarea.bp6-input.bp6-active {
     border-color: #8b5cf6 !important;
     box-shadow:
       inset 0 0 0 1px #8b5cf6,
@@ -614,14 +614,14 @@ body.bp4-dark.high-contrast-theme {
     outline: none !important;
   }
 
-  .bp4-dialog-header {
+  .bp6-dialog-header {
     background-color: @hc-dark-bg !important;
     border-bottom: 1px solid @hc-dark-border !important;
     color: @hc-text-color !important;
     box-shadow: none !important;
   }
 
-  .bp4-dialog-close-button .bp4-icon {
+  .bp6-dialog-close-button .bp6-icon {
     color: #9ca3af !important;
     &:hover {
       color: #ffffff !important;

--- a/src/styles/blueprint.less
+++ b/src/styles/blueprint.less
@@ -27,7 +27,7 @@ body {
   }
 
   .bp6-input,
-  // class of TagInput (also used by MultiSelect2)
+  // class of TagInput (also used by MultiSelect)
   .bp6-input-ghost {
     @apply placeholder:italic placeholder:text-slate-400;
   }
@@ -515,7 +515,7 @@ body.bp6-dark.high-contrast-theme {
     }
   }
 
-  .bp6-tooltip2 {
+  .bp6-tooltip {
     .bp6-popover-content {
       background-color: @hc-dark-bg !important;
       border: 1px solid @hc-dark-border !important;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -63,13 +63,13 @@ body,
     0 0 3px 1px #0001,
     0 2px 3px #0001;
 
-  &.bp4-interactive:hover {
+  &.bp6-interactive:hover {
     box-shadow:
       0 2px 4px #0002,
       0 8px 24px #0003;
   }
 
-  &.bp4-interactive:active {
+  &.bp6-interactive:active {
     box-shadow:
       0 0 3px 1px #0001,
       0 2px 3px #0001;

--- a/src/utils/wrapErrorMessage.ts
+++ b/src/utils/wrapErrorMessage.ts
@@ -1,19 +1,19 @@
-import { IToastProps } from '@blueprintjs/core'
+import { ToastProps } from '@blueprintjs/core'
 
 import { AppToaster } from 'components/Toaster'
 
 export type MessageFormatter = (error: unknown) => string
 
-const defaultMessageProps: Partial<IToastProps> = {
+const defaultMessageProps: Partial<ToastProps> = {
   intent: 'danger',
 }
 
 export const wrapErrorMessage = <T>(
-  options: string | MessageFormatter | Omit<IToastProps, 'intent'>,
+  options: string | MessageFormatter | Omit<ToastProps, 'intent'>,
   promise: Promise<T>,
 ): Promise<T> => {
   return promise.catch((error) => {
-    const config: IToastProps = (() => {
+    const config: ToastProps = (() => {
       switch (typeof options) {
         case 'string':
           return {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,14 @@ import { generateTranslations } from './scripts/generate-translations'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
+// TODO(blueprint-v6 / @popperjs/core 补丁): 移除 patches/@popperjs__core@2.11.8.patch
+// 当前 Rolldown(Vite 8 打包器）在 app 打包下无法解析 @popperjs/core 经 `export *` 重导出、
+// 且带 `/*#__PURE__*/` 注解的 `placements`，导致 Blueprint v6 legacy Popover 的
+// `export { placements as PopperPlacements }` 构建失败（MISSING_EXPORT）。
+// 注意：rolldown#9122/#9958 只修了 preserveModules 库模式（已在 1.1.3 中，但不覆盖本场景）。
+// 待 Rolldown 发布覆盖 app-bundle export* 的修复后：删除上面的 patch 条目 +
+// `package.json` 里的 pnpm.patchedDependencies，重新 `pnpm install && pnpm build` 验证即可。
+
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
   // Load env file based on `mode` in the current working directory.
@@ -41,7 +49,7 @@ export default defineConfig(({ command, mode }) => {
                 test: /node_modules[\\/](react-use|react-rating|react-markdown|react-ga-neo|react-hook-form)[\\/]/,
               },
               { name: 'blueprint', test: /node_modules[\\/]@blueprintjs[\\/]core[\\/]/ },
-              { name: 'blueprintaddon', test: /node_modules[\\/]@blueprintjs[\\/](select|popover2)[\\/]/ },
+              { name: 'blueprintaddon', test: /node_modules[\\/]@blueprintjs[\\/]select[\\/]/ },
               { name: 'sentry', test: /node_modules[\\/]@sentry[\\/](react|tracing)[\\/]/ },
               { name: 'dnd', test: /node_modules[\\/]@dnd-kit[\\/]/ },
               { name: 'jotai', test: /node_modules[\\/](jotai|immer)[\\/]/ },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,8 +14,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url))
 // 且带 `/*#__PURE__*/` 注解的 `placements`，导致 Blueprint v6 legacy Popover 的
 // `export { placements as PopperPlacements }` 构建失败（MISSING_EXPORT）。
 // 注意：rolldown#9122/#9958 只修了 preserveModules 库模式（已在 1.1.3 中，但不覆盖本场景）。
-// 待 Rolldown 发布覆盖 app-bundle export* 的修复后：删除上面的 patch 条目 +
-// `package.json` 里的 pnpm.patchedDependencies，重新 `pnpm install && pnpm build` 验证即可。
+// 待 Rolldown 发布覆盖 app-bundle export* 的修复后：删除 patches/ 里的补丁文件 +
+// `pnpm-workspace.yaml` 里的 patchedDependencies 条目，重新 `pnpm install && pnpm build` 验证即可。
 
 // https://vitejs.dev/config/
 export default defineConfig(({ command, mode }) => {
@@ -52,7 +52,7 @@ export default defineConfig(({ command, mode }) => {
               { name: 'blueprintaddon', test: /node_modules[\\/]@blueprintjs[\\/]select[\\/]/ },
               { name: 'sentry', test: /node_modules[\\/]@sentry[\\/](react|tracing)[\\/]/ },
               { name: 'dnd', test: /node_modules[\\/]@dnd-kit[\\/]/ },
-              { name: 'jotai', test: /node_modules[\\/](jotai|immer)[\\/]/ },
+              { name: 'jotai', test: /node_modules[\\/](jotai|jotai-[^\\/]+|immer)[\\/]/ },
               { name: 'remark', test: /node_modules[\\/](remark-gfm|remark-breaks)[\\/]/ },
               { name: 'iconify', test: /node_modules[\\/]@iconify[\\/]react[\\/]/ },
               { name: 'ajv', test: /node_modules[\\/](ajv|ajv-i18n)[\\/]/ },


### PR DESCRIPTION
- 依赖 core/icons/select 升级至 ^6，移除 @blueprintjs/popover2
- popover2 组件合回 core；standalone Popover2 → PopoverNext， minimal/position/modifiersCustom 转为 animation+arrow/placement/middleware
- CreateActionMenu 改用 PopoverNextRef.reposition() 替代 Popper 实例 hack
- select v4→v6 去后缀；删除已被上游修复的 handleItemSelect 补丁，保留 QueryList #3751 补丁
- 图标改异步加载，main.tsx 预加载全部图标
- CSS 前缀 bp4- → bp6-；OverlayToaster 异步 create 加同步门面
- 修复 growVertically/size/InputGroupProps2/IToastProps 等 v6 破坏性变更
- patch @popperjs/core 绕过 Rolldown 对 export* 的解析限制（见 vite.config TODO）

## Summary by Sourcery

将应用从 Blueprint v4 升级到 v6，使用新的 PopoverNext 和 v6 组件替换旧版的 popover/tooltip/select API，并相应更新样式、主题以及依赖代码。

新功能：
- 在启动时主动预加载所有 Blueprint v6 图标，以尽量减少异步加载图标带来的空档。

错误修复：
- 调整 toast、input、textarea、numeric input 及相关 props/用法，以适配 Blueprint v6 的不兼容变更，保持现有行为不变。
- 为 @popperjs/core 打补丁，以绕过 Rolldown 对 `export*` 的限制对 Blueprint v6 legacy Popover 构建造成的问题。
- 通过对齐 Blueprint v6 API 并移除过时的本地补丁，修复 Select/Suggest/Multiselect 的行为。
- 确保从应用视角看 OverlayToaster 的使用保持同步，即使在 v6 中其 create API 变为异步。

增强：
- 将所有自定义 Blueprint 样式以及暗色/高对比模式的类名从 `bp4-` 迁移到 `bp6-`，包括 popover、dialog、toast、menu 和 skeleton 等。
- 在整个 UI 中（包括编辑器、查看器、上传器、导航和账户组件），用 PopoverNext/Tooltip/MenuItem 替换 Popover2/Tooltip2/MenuItem2。
- 基于基于 Floating UI 的 PopoverNext 统一操作/编辑器 UI 行为（自动保存、历史记录、过滤器、操作菜单、评分等）。
- 更新构建和 CI 配置（vite rollupOptions、pnpm workspace 的 patchedDependencies、CI workflow），以适配 Blueprint v6 工具链和打包行为。
- 根据 Blueprint v6 的语义调整各种布局和 UX 细节（InputGroup/FloatingMap 的 spinner、InfoEditor 表单布局、按钮/图标工具类）。

构建：
- 优化 Vite rollupOptions 的 chunk 划分以适配 Blueprint v6，并更新注释，用于记录 Rolldown/@popperjs/core 的交互行为。

CI：
- 扩展 CI workflow，在 lint 之后运行一次快速的 Vite 构建，以捕获构建期回归问题。

杂项：
- 将 @blueprintjs/core、@blueprintjs/icons 和 @blueprintjs/select 升级到 v6，并相应重新对齐项目依赖。
- 为 @popperjs/core 2.11.8 引入一个 pnpm patchedDependencies 条目及对应补丁文件，以在 Rolldown 下解除构建阻塞。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the app from Blueprint v4 to v6, replacing legacy popover/tooltip/select APIs with the new PopoverNext and v6 components while updating styles, theming, and dependent code accordingly.

New Features:
- Eagerly preload all Blueprint v6 icons at startup to minimize async icon loading gaps.

Bug Fixes:
- Adapt toast, input, textarea, numeric input, and related props/usages to Blueprint v6 breaking changes to preserve existing behavior.
- Patch @popperjs/core to work around Rolldown export* limitations affecting Blueprint v6 legacy Popover builds.
- Fix Select/Suggest/Multiselect behavior by aligning with Blueprint v6 APIs and removing obsolete local patches.
- Ensure OverlayToaster usage remains synchronous from the app’s perspective despite v6’s async create API.

Enhancements:
- Retheme all custom Blueprint styles and dark/high-contrast modes from bp4- to bp6- classnames, including popovers, dialogs, toasts, menus, and skeletons.
- Replace Popover2/Tooltip2/MenuItem2 with PopoverNext/Tooltip/MenuItem across the UI, including editors, viewers, uploaders, nav, and account components.
- Standardize operation/editor UI behaviors (autosave, history, filters, action menus, rating, etc.) on Floating UI-based PopoverNext.
- Update build and CI configuration (vite rollupOptions, pnpm workspace patchedDependencies, CI workflow) for the Blueprint v6 toolchain and bundler behavior.
- Adjust various layout and UX details (InputGroup/FloatingMap spinners, InfoEditor form layout, button/icon utility classes) for Blueprint v6 semantics.

Build:
- Refine Vite rollupOptions chunking for Blueprint v6 and update comments documenting Rolldown/@popperjs/core interactions.

CI:
- Extend the CI workflow to run a fast Vite build after linting to catch build-time regressions.

Chores:
- Bump @blueprintjs/core, @blueprintjs/icons, and @blueprintjs/select to v6 and realign project dependencies accordingly.
- Introduce a pnpm patchedDependencies entry and accompanying patch file for @popperjs/core 2.11.8 to unblock builds under Rolldown.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将应用从 Blueprint v4 升级到 v6，使用新的 PopoverNext 和 v6 组件替换旧版的 popover/tooltip/select API，并相应更新样式、主题以及依赖代码。

新功能：
- 在启动时主动预加载所有 Blueprint v6 图标，以尽量减少异步加载图标带来的空档。

错误修复：
- 调整 toast、input、textarea、numeric input 及相关 props/用法，以适配 Blueprint v6 的不兼容变更，保持现有行为不变。
- 为 @popperjs/core 打补丁，以绕过 Rolldown 对 `export*` 的限制对 Blueprint v6 legacy Popover 构建造成的问题。
- 通过对齐 Blueprint v6 API 并移除过时的本地补丁，修复 Select/Suggest/Multiselect 的行为。
- 确保从应用视角看 OverlayToaster 的使用保持同步，即使在 v6 中其 create API 变为异步。

增强：
- 将所有自定义 Blueprint 样式以及暗色/高对比模式的类名从 `bp4-` 迁移到 `bp6-`，包括 popover、dialog、toast、menu 和 skeleton 等。
- 在整个 UI 中（包括编辑器、查看器、上传器、导航和账户组件），用 PopoverNext/Tooltip/MenuItem 替换 Popover2/Tooltip2/MenuItem2。
- 基于基于 Floating UI 的 PopoverNext 统一操作/编辑器 UI 行为（自动保存、历史记录、过滤器、操作菜单、评分等）。
- 更新构建和 CI 配置（vite rollupOptions、pnpm workspace 的 patchedDependencies、CI workflow），以适配 Blueprint v6 工具链和打包行为。
- 根据 Blueprint v6 的语义调整各种布局和 UX 细节（InputGroup/FloatingMap 的 spinner、InfoEditor 表单布局、按钮/图标工具类）。

构建：
- 优化 Vite rollupOptions 的 chunk 划分以适配 Blueprint v6，并更新注释，用于记录 Rolldown/@popperjs/core 的交互行为。

CI：
- 扩展 CI workflow，在 lint 之后运行一次快速的 Vite 构建，以捕获构建期回归问题。

杂项：
- 将 @blueprintjs/core、@blueprintjs/icons 和 @blueprintjs/select 升级到 v6，并相应重新对齐项目依赖。
- 为 @popperjs/core 2.11.8 引入一个 pnpm patchedDependencies 条目及对应补丁文件，以在 Rolldown 下解除构建阻塞。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the app from Blueprint v4 to v6, replacing legacy popover/tooltip/select APIs with the new PopoverNext and v6 components while updating styles, theming, and dependent code accordingly.

New Features:
- Eagerly preload all Blueprint v6 icons at startup to minimize async icon loading gaps.

Bug Fixes:
- Adapt toast, input, textarea, numeric input, and related props/usages to Blueprint v6 breaking changes to preserve existing behavior.
- Patch @popperjs/core to work around Rolldown export* limitations affecting Blueprint v6 legacy Popover builds.
- Fix Select/Suggest/Multiselect behavior by aligning with Blueprint v6 APIs and removing obsolete local patches.
- Ensure OverlayToaster usage remains synchronous from the app’s perspective despite v6’s async create API.

Enhancements:
- Retheme all custom Blueprint styles and dark/high-contrast modes from bp4- to bp6- classnames, including popovers, dialogs, toasts, menus, and skeletons.
- Replace Popover2/Tooltip2/MenuItem2 with PopoverNext/Tooltip/MenuItem across the UI, including editors, viewers, uploaders, nav, and account components.
- Standardize operation/editor UI behaviors (autosave, history, filters, action menus, rating, etc.) on Floating UI-based PopoverNext.
- Update build and CI configuration (vite rollupOptions, pnpm workspace patchedDependencies, CI workflow) for the Blueprint v6 toolchain and bundler behavior.
- Adjust various layout and UX details (InputGroup/FloatingMap spinners, InfoEditor form layout, button/icon utility classes) for Blueprint v6 semantics.

Build:
- Refine Vite rollupOptions chunking for Blueprint v6 and update comments documenting Rolldown/@popperjs/core interactions.

CI:
- Extend the CI workflow to run a fast Vite build after linting to catch build-time regressions.

Chores:
- Bump @blueprintjs/core, @blueprintjs/icons, and @blueprintjs/select to v6 and realign project dependencies accordingly.
- Introduce a pnpm patchedDependencies entry and accompanying patch file for @popperjs/core 2.11.8 to unblock builds under Rolldown.

</details>

</details>