### PR TITLE
chore: 统一品牌为 PRTS Plus

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="PRTS Plus 作业站 — 为用户提供 JSON 作业" />
-    <meta name="keywords" content="明日方舟,作业站,自动刷图,明日方舟作业站" />
+    <meta name="keywords" content="明日方舟,作业站,明日方舟作业站,PRTS Plus" />
     <title>PRTS Plus</title>
 
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=2" />

--- a/src/components/AccountManager.tsx
+++ b/src/components/AccountManager.tsx
@@ -97,7 +97,7 @@ export const AccountAuthDialog: ComponentType<{
   const [activeTab, setActiveTab] = useState<TabId>('login')
 
   return (
-    <Dialog title={t.components.AccountManager.maa_account} icon="user" isOpen={open} onClose={onClose}>
+    <Dialog title={t.components.AccountManager.account} icon="user" isOpen={open} onClose={onClose}>
       <div className="flex flex-col p-4 pt-2">
         <GlobalErrorBoundary>
           <Tabs

--- a/src/components/announcement/AnnPanel.tsx
+++ b/src/components/announcement/AnnPanel.tsx
@@ -20,7 +20,7 @@ export const AnnPanel: FC<AnnPanelProps> = ({ className, trigger }) => {
   const t = useTranslation()
   const { data, error } = useAnnouncement()
   const announcement = useMemo(() => (data ? parseAnnouncement(data) : undefined), [data])
-  const [lastNoticed, setLastNoticed] = useLazyStorage('copilot-last-noticed', 0)
+  const [lastNoticed, setLastNoticed] = useLazyStorage('zoot-plus-last-noticed', 0)
   const [displaySections, setDisplaySections] = useState<AnnouncementSection[]>()
 
   const [isOpen, setIsOpen] = useState<{ yes: boolean; manually: boolean }>()

--- a/src/components/editor/floatingMap/FloatingMap.tsx
+++ b/src/components/editor/floatingMap/FloatingMap.tsx
@@ -24,7 +24,7 @@ interface FloatingMapConfig {
 }
 
 const UID = 'floating-map'
-const STORAGE_KEY = `copilot-${UID}`
+const STORAGE_KEY = `zoot-plus-${UID}`
 
 const HEADER_CLASS = 'floating-map-header'
 

--- a/src/components/editor/source/SourceEditorHeader.tsx
+++ b/src/components/editor/source/SourceEditorHeader.tsx
@@ -45,7 +45,7 @@ export const SourceEditorHeader: FC<SourceEditorHeaderProps> = ({ text, onChange
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = url
-    link.download = `MAACopilot_${title || t.components.editor.source.SourceEditorHeader.untitled}.json`
+    link.download = `PRTSPlus_${title || t.components.editor.source.SourceEditorHeader.untitled}.json`
     link.click()
     URL.revokeObjectURL(url)
 

--- a/src/components/editor2/useAutoSave.ts
+++ b/src/components/editor2/useAutoSave.ts
@@ -30,7 +30,7 @@ export class NotChangedError extends Error {
 
 const defaultEditorStateStringified = JSON.stringify(defaultEditorState)
 
-export const editorArchiveAtom = atomWithStorage('maa-copilot-editor2-autosave', [] as Archive)
+export const editorArchiveAtom = atomWithStorage('zoot-plus-editor2-autosave', [] as Archive)
 export const editorSaveAtom = atom(noop, (get, set) => {
   const state = get(editorAtoms.editor)
   const dehydratedState = {

--- a/src/components/viewer/OperationSetViewer.tsx
+++ b/src/components/viewer/OperationSetViewer.tsx
@@ -142,7 +142,7 @@ export const OperationSetViewer: ComponentType<{
         title={
           <>
             <Icon icon="document" />
-            <span className="ml-2">{t.components.viewer.OperationSetViewer.maa_copilot_task_set}</span>
+            <span className="ml-2">{t.components.viewer.OperationSetViewer.task_set}</span>
 
             <div className="flex-1" />
 

--- a/src/components/viewer/OperationViewer.tsx
+++ b/src/components/viewer/OperationViewer.tsx
@@ -28,6 +28,7 @@ import { ComponentType, FC, useEffect, useState } from 'react'
 import { copyShortCode, handleDownloadJSON } from 'services/operation'
 
 import { FactItem } from 'components/FactItem'
+import { HelperText } from 'components/HelperText'
 import { Paragraphs } from 'components/Paragraphs'
 import { RelativeTime } from 'components/RelativeTime'
 import { withSuspensable } from 'components/Suspensable'
@@ -299,7 +300,7 @@ export const OperationViewer: ComponentType<{
         title={
           <>
             <Icon icon="document" />
-            <span className="ml-2">{t.components.viewer.OperationViewer.maa_copilot_task}</span>
+            <span className="ml-2">{t.components.viewer.OperationViewer.task}</span>
 
             <div className="flex-1" />
 
@@ -652,6 +653,9 @@ function OperationViewerInnerDetails({ operation }: { operation: Operation }) {
       <Collapse isOpen={showActions}>
         {operation.parsedContent.actions?.length ? (
           <>
+            <HelperText className="mt-2 [&_a]:inline">
+              <span dangerouslySetInnerHTML={{ __html: t.components.viewer.OperationViewer.coordinate_hint }} />
+            </HelperText>
             {gridMode ? (
               <GridTimeline actions={operation.parsedContent.actions} groups={operation.parsedContent.groups} />
             ) : (

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -106,7 +106,7 @@ export const allEssentials = Object.fromEntries(
   ]),
 ) as Record<Language, I18NEssentials>
 
-const languageStorageKey = 'maa-copilot-lang'
+const languageStorageKey = 'zoot-plus-lang'
 
 let currentLanguage: Language
 let currentTranslations: I18NTranslations | undefined

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -2838,7 +2838,7 @@
           "cn": "刷新作业集失败：{{error}}",
           "en": "Failed to refresh Job set: {{error}}"
         },
-        "maa_copilot_task_set": {
+        "task_set": {
           "cn": "PRTS Plus 作业集",
           "en": "PRTS Plus Job Set"
         },
@@ -2944,7 +2944,7 @@
           "cn": "提交评分失败：{{error}}",
           "en": "Failed to submit rating: {{error}}"
         },
-        "maa_copilot_task": {
+        "task": {
           "cn": "PRTS Plus 作业",
           "en": "PRTS Plus Job"
         },
@@ -3058,6 +3058,10 @@
           "cn": "动作序列",
           "en": "Action Sequence"
         },
+        "coordinate_hint": {
+          "cn": "坐标可在地图站（<a href=\"https://map.ark-nights.com/\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-blue-500 hover:underline\">PRTS.Map</a>）中查看，需在设置中将坐标展示改为 MAA 体系",
+          "en": "Coordinates can be viewed on <a href=\"https://map.ark-nights.com/\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-blue-500 hover:underline\">PRTS.Map</a>; change coordinate display to MAA in settings"
+        },
         "no_actions": {
           "cn": "暂无动作",
           "en": "No Actions"
@@ -3109,7 +3113,7 @@
         "cn": "修改信息...",
         "en": "Edit Information"
       },
-      "maa_account": {
+      "account": {
         "cn": "PRTS Plus 账户",
         "en": "PRTS Plus Account"
       },
@@ -4175,8 +4179,8 @@
         "en": "JSON data error, please contact the developer"
       },
       "shortcode_copied": {
-        "cn": "已复制神秘代码，在客户端粘贴即可使用~",
-        "en": "Secret code copied, paste it in the client to use it~"
+        "cn": "已复制神秘代码~",
+        "en": "Secret code copied~"
       },
       "shortcode_copy_failed": {
         "cn": "复制神秘代码失败：{{error}}",
@@ -4215,7 +4219,7 @@
         "en": "Request error"
       }
     },
-    "maa_copilot_client": {
+    "api_client": {
       "invalid_response": {
         "cn": "返回值无效",
         "en": "Invalid response"
@@ -4247,10 +4251,6 @@
       "cn": "关于",
       "en": "About"
     },
-    "official_site": {
-      "cn": "相关项目",
-      "en": "Related Project"
-    },
     "map_site": {
       "cn": "明日方舟地图站",
       "en": "Arknights PRTS.Map"
@@ -4259,17 +4259,13 @@
       "cn": "特蕾西娅",
       "en": "Theresa"
     },
-    "maafw_site": {
-      "cn": "黑盒测试框架",
-      "en": "Black-box Framework"
+    "yituliu_site": {
+      "cn": "一图流",
+      "en": "Yituliu"
     },
     "feedback": {
       "cn": "意见与反馈",
       "en": "Feedback"
-    },
-    "maa_repo": {
-      "cn": "小工具",
-      "en": "Assistant Tool"
     },
     "frontend_repo": {
       "cn": "前端 GitHub Repo",
@@ -4282,10 +4278,6 @@
     "creator_group": {
       "cn": "作业制作者交流群：{{groupNumber}}",
       "en": "Creator Community Group: {{groupNumber}}"
-    },
-    "sharing_group": {
-      "cn": "作业分享群",
-      "en": "Job Sharing Group"
     },
     "friendly_links": {
       "cn": "友情链接",

--- a/src/links.tsx
+++ b/src/links.tsx
@@ -49,24 +49,9 @@ export const SOCIAL_CONFIG = [
     href: 'https://jq.qq.com/?_wv=1027&k=ElimpMzQ',
     labelKey: () => i18n.links.creator_group({ groupNumber: '1169188429' }),
   },
-  {
-    icon: <IconifyIcon icon={simpleIconsQQ} className="mr-2" fontSize="12px" />,
-    href: 'https://api.maa.plus/MaaAssistantArknights/api/qqgroup/index.html',
-    labelKey: i18nDefer.links.sharing_group,
-  },
 ]
 
 export const FRIENDLY_LINKS_CONFIG = [
-  {
-    icon: <BlueprintIcon icon="globe" className="mr-2" size={12} />,
-    href: 'https://maa.plus',
-    labelKey: i18nDefer.links.official_site,
-  },
-  {
-    icon: <IconifyIcon icon={simpleIconsGitHub} className="mr-2" fontSize="12px" />,
-    href: 'https://github.com/MaaAssistantArknights/MaaAssistantArknights',
-    labelKey: i18nDefer.links.maa_repo,
-  },
   {
     icon: <BlueprintIcon icon="globe" className="mr-2" size={12} />,
     href: 'https://map.ark-nights.com/',
@@ -79,7 +64,7 @@ export const FRIENDLY_LINKS_CONFIG = [
   },
   {
     icon: <BlueprintIcon icon="globe" className="mr-2" size={12} />,
-    href: 'https://maafw.xyz/',
-    labelKey: i18nDefer.links.maafw_site,
+    href: 'https://ark.yituliu.cn/',
+    labelKey: i18nDefer.links.yituliu_site,
   },
 ]

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -51,6 +51,21 @@ if (navigator.userAgent.includes('Win')) {
 
 clearOutdatedSwrCache()
 
+// 将 maa-copilot-* / copilot-* 的 localStorage 数据迁移到 zoot-plus-* 前缀
+;(function migrateStorageKeys() {
+  for (let i = localStorage.length - 1; i >= 0; i--) {
+    const key = localStorage.key(i)
+    if (!key) continue
+    const newKey = key
+      .replace(/^maa-copilot-/, 'zoot-plus-')
+      .replace(/^copilot-/, 'zoot-plus-')
+    if (newKey !== key && localStorage.getItem(newKey) === null) {
+      localStorage.setItem(newKey, localStorage.getItem(key)!)
+      localStorage.removeItem(key)
+    }
+  }
+})()
+
 // v6 起 Blueprint 图标改为按需异步加载（dynamic import）。这里改用 'all' loader 并尽早
 // 触发一次性全量加载，尽量缩短图标缺失窗口。注意：与 v4 的同步内联不同，加载仍是异步的，
 // 首帧若早于图标 chunk 到达，可能短暂渲染空图标——这是 v6 的设计取舍，此处不阻塞首帧。

--- a/src/models/copilot.schema.json
+++ b/src/models/copilot.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "title": "Maa Copilot Operation",
+  "title": "Copilot Operation",
   "properties": {
     "stage_name": {
       "$ref": "#/definitions/stage_name"

--- a/src/models/copilot.schema.ts
+++ b/src/models/copilot.schema.ts
@@ -1,7 +1,7 @@
 import { OpDifficulty } from './operation'
 
 /**
- * MAA Copilot 战斗协议 v1
+ * 战斗流程协议 v1
  * https://maa.plus/docs/zh-cn/protocol/copilot-schema.html
  */
 export namespace CopilotDocV1 {

--- a/src/models/level.ts
+++ b/src/models/level.ts
@@ -6,7 +6,7 @@
  * 2. act1bossrush_01 / act1bossrush_tm01
  * 3. ro1_e_1_1 / ro1_n_1_1
  *
- * Only the first two kinds are supported in MAA Copilot.
+ * Only the first two kinds are supported in PRTS Plus.
  */
 import { i18n } from '../i18n/i18n'
 import { Level, OpDifficulty } from './operation'

--- a/src/models/operator.ts
+++ b/src/models/operator.ts
@@ -324,6 +324,7 @@ export interface ActionDocColor {
 
 // Colors from
 // https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/50f5f94dfcc2ec175556bbaa55d0ffec74128a8e/src/MeoAsstGui/Helper/LogColor.cs
+// 上游协议规范的日志颜色定义
 export const actionDocColors: ActionDocColor[] = [
   {
     title: i18nDefer.models.operator.color.gray,

--- a/src/pages/create.tsx
+++ b/src/pages/create.tsx
@@ -56,7 +56,7 @@ export const CreatePage: ComponentType = withGlobalErrorBoundary(
 
     const autosaveOptions: AutosaveOptions<CopilotDocV1.Operation> = useMemo(
       () => ({
-        key: 'maa-copilot-editor',
+        key: 'zoot-plus-editor',
         interval: 1000 * 60,
         limit: 20,
         shouldSave: (operation, archive) => isChangedSinceLastSave(operation, archive) && isDirty(operation),

--- a/src/services/operation.ts
+++ b/src/services/operation.ts
@@ -29,7 +29,7 @@ export const handleDownloadJSON = (operationDoc: CopilotDocV1.Operation) => {
     2,
   )
 
-  doTriggerDownloadJSON(json, `MAACopilot_${operationDoc.doc.title}.json`)
+  doTriggerDownloadJSON(json, `PRTSPlus_${operationDoc.doc.title}.json`)
 
   AppToaster.show({
     message: i18n.services.operation.json_downloaded,
@@ -50,7 +50,7 @@ export const handleLazyDownloadJSON = async (id: number, title: string) => {
 
   try {
     const json = JSON.stringify(snakeCaseKeysUnicode(JSON.parse(resp.data!.content) as any), null, 2)
-    doTriggerDownloadJSON(json, `MAACopilot_${title}.json`)
+    doTriggerDownloadJSON(json, `PRTSPlus_${title}.json`)
     AppToaster.show({
       message: i18n.services.operation.json_downloaded,
       intent: 'success',

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -13,7 +13,7 @@ export interface AuthState {
   username?: string
 }
 
-export const authAtom = atomWithStorage<AuthState>('maa-copilot-auth', {}, undefined, {
+export const authAtom = atomWithStorage<AuthState>('zoot-plus-auth', {}, undefined, {
   getOnInit: true,
 })
 

--- a/src/store/selectedOperators.ts
+++ b/src/store/selectedOperators.ts
@@ -15,14 +15,14 @@ export const DEFAULT_OPERATOR_FILTER: OperatorFilterData = {
 }
 
 export const operatorFilterAtom = atomWithStorage<OperatorFilterData>(
-  'maa-copilot-operatorFilter',
+  'zoot-plus-operatorFilter',
   DEFAULT_OPERATOR_FILTER,
   undefined,
   { getOnInit: true },
 )
 
 // 删除旧版数据
-if (localStorage.getItem('maa-copilot-selectedOperators')) {
-  localStorage.removeItem('maa-copilot-selectedOperators')
-  localStorage.removeItem('maa-copilot-saveSelectedOperators')
+if (localStorage.getItem('zoot-plus-selectedOperators')) {
+  localStorage.removeItem('zoot-plus-selectedOperators')
+  localStorage.removeItem('zoot-plus-saveSelectedOperators')
 }

--- a/src/store/selectedOperators.ts
+++ b/src/store/selectedOperators.ts
@@ -20,9 +20,3 @@ export const operatorFilterAtom = atomWithStorage<OperatorFilterData>(
   undefined,
   { getOnInit: true },
 )
-
-// 删除旧版数据
-if (localStorage.getItem('zoot-plus-selectedOperators')) {
-  localStorage.removeItem('zoot-plus-selectedOperators')
-  localStorage.removeItem('zoot-plus-saveSelectedOperators')
-}

--- a/src/store/useFavGroups.ts
+++ b/src/store/useFavGroups.ts
@@ -8,7 +8,7 @@ export const ignoreKeyDic = ['_id', 'id'] as const
 type Group = CopilotDocV1.Group
 export type FavGroup = Omit<Group, (typeof ignoreKeyDic)[number]>
 
-const favGroupCoreAtom = atomWithStorage<FavGroup[]>('maa-copilot-fav-groups', [])
+const favGroupCoreAtom = atomWithStorage<FavGroup[]>('zoot-plus-fav-groups', [])
 
 export const favGroupAtom = atom(
   (get) => get(favGroupCoreAtom),

--- a/src/store/useFavOperators.ts
+++ b/src/store/useFavOperators.ts
@@ -9,7 +9,7 @@ export type FavOperator = Omit<Operator, (typeof operatorIgnoreKeyDic)[number]>
 
 export const operatorIgnoreKeyDic = ['id', '_id'] as const
 
-const favOperatorCoreAtom = atomWithStorage<FavOperator[]>('maa-copilot-fav-operator', [])
+const favOperatorCoreAtom = atomWithStorage<FavOperator[]>('zoot-plus-fav-operator', [])
 
 export const favOperatorAtom = atom(
   (get) => get(favOperatorCoreAtom),

--- a/src/utils/maa-copilot-client.ts
+++ b/src/utils/maa-copilot-client.ts
@@ -217,20 +217,20 @@ JSONApiResponse.prototype.value = async function value() {
   if (validateStatusCode === 'always' || requireData) {
     if (!isObject(result)) {
       console.error('response is not an object', result)
-      throw new ApiError(i18n.utils.maa_copilot_client.invalid_response)
+      throw new ApiError(i18n.utils.api_client.invalid_response)
     }
   }
 
   if (validateStatusCode === 'always' || (validateStatusCode === 'if-object' && isObject(result))) {
     if (result.statusCode !== 200) {
       console.error('response.statusCode is not 200', result)
-      throw new ApiError(result.message || i18n.utils.maa_copilot_client.server_error)
+      throw new ApiError(result.message || i18n.utils.api_client.server_error)
     }
   }
 
   if (requireData && (result.data === undefined || result.data === null)) {
     console.error('response.data is missing', result)
-    throw new ApiError(result.message || i18n.utils.maa_copilot_client.invalid_response)
+    throw new ApiError(result.message || i18n.utils.api_client.invalid_response)
   }
 
   return result

--- a/src/utils/swr.ts
+++ b/src/utils/swr.ts
@@ -1,6 +1,6 @@
 import { useSWRConfig } from 'swr'
 
-const STORAGE_KEY = 'copilot-swr'
+const STORAGE_KEY = 'zoot-plus-swr'
 
 // 清理旧版本留下的缓存数据
 // TODO: 等大部分用户都升级到新版本，就删除这个函数，大概在三个月之后？


### PR DESCRIPTION
## Summary by Sourcery

将产品品牌与存储前缀从 MAA Copilot 统一迁移到 PRTS Plus，并同时更新相关的 UI 文本、下载文件名和元数据。

Enhancements:
- 将 `localStorage` 键从 `maa-copilot*`/`copilot*` 前缀迁移到 `zoot-plus*`，并更新所有相关的 atoms 和存储键。
- 更新面向用户的标签、对话框标题和辅助文本，移除 MAA 相关措辞，改为通用或 PRTS Plus 的术语。
- 将 JSON 下载文件名中的前缀从 `MAACopilot` 改为 `PRTSPlus`，并调整协议注释以反映新的品牌。
- 刷新 HTML 元数据关键词以包含 PRTS Plus，并使关卡文档与当前平台支持保持一致。
- 在作战查看器的详情部分添加坐标使用的辅助说明，以提供更清晰的指引。

Chores:
- 移除过期的社交和友情链接，并将一个友情链接从原来的 `maafw` 域更新为指向 `yituliu` 站点。
- 将公告和编辑器悬浮地图的存储键重新定位到新的 `zoot-plus` 前缀，并调整 SWR 缓存存储的命名。
- 对 API 客户端的 i18n 键进行常规清理，将 `maa_copilot_client` 更改为 `api_client`，以匹配新的命名方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify product branding and storage prefixes from MAA Copilot to PRTS Plus while updating related UI text, download filenames, and metadata.

Enhancements:
- Migrate localStorage keys from maa-copilot*/copilot* prefixes to zoot-plus* and update all related atoms and storage keys.
- Update user-facing labels, dialog titles, and helper texts to remove MAA-specific wording in favor of generic or PRTS Plus terminology.
- Change JSON download filenames to use the PRTSPlus prefix instead of MAACopilot and adjust protocol comments to reflect the new branding.
- Refresh HTML metadata keywords to include PRTS Plus and align level documentation with current platform support.
- Add coordinate usage helper text to the operation viewer details section for better guidance.

Chores:
- Remove outdated social and friendly links and update a friendly link to point to the yituliu site instead of the previous maafw domain.
- Retarget announcement and editor floating map storage keys to the new zoot-plus prefix and adjust SWR cache storage naming.
- General cleanup of API client i18n keys from maa_copilot_client to api_client to match the new naming scheme.

</details>