### PR TITLE
feat: add Yituliu operator matcher

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 # 本地开发端口
-PORT=3000
+PORT=3333
 
 # 如果需要使用生产环境的API，请把下面一行注释掉，或者在.env.development.local中覆盖
 VITE_API=https://prts.maa.plus

--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 # 本地开发端口
-PORT=3333
+PORT=3000
 
 # 如果需要使用生产环境的API，请把下面一行注释掉，或者在.env.development.local中覆盖
 VITE_API=https://prts.maa.plus

--- a/src/components/OperationList.tsx
+++ b/src/components/OperationList.tsx
@@ -2,11 +2,12 @@ import { Button, Callout, NonIdealState, Tooltip } from '@blueprintjs/core'
 
 import { UseOperationsParams, useOperations } from 'apis/operation'
 import { useAtomValue } from 'jotai'
-import { ComponentType, ReactNode, useEffect, useState } from 'react'
+import { ComponentType, ReactNode, useEffect, useMemo, useRef, useState } from 'react'
 
 import { neoLayoutAtom } from 'store/pref'
 
 import { useTranslation } from '../i18n/i18n'
+import { OperatorMatcherFilter, getOperationMatchResult } from '../models/operatorMatcher'
 import { Operation } from '../models/operation'
 import { NeoOperationCard, OperationCard } from './OperationCard'
 import { withSuspensable } from './Suspensable'
@@ -15,10 +16,11 @@ import { AddToOperationSetButton } from './operation-set/AddToOperationSet'
 interface OperationListProps extends UseOperationsParams {
   multiselect?: boolean
   onUpdate?: (params: { total: number }) => void
+  operatorMatcher?: OperatorMatcherFilter
 }
 
 export const OperationList: ComponentType<OperationListProps> = withSuspensable(
-  ({ multiselect, onUpdate, ...params }) => {
+  ({ multiselect, onUpdate, operatorMatcher, ...params }) => {
     const t = useTranslation()
     const neoLayout = useAtomValue(neoLayoutAtom)
 
@@ -30,9 +32,45 @@ export const OperationList: ComponentType<OperationListProps> = withSuspensable(
     // make TS happy: we got Suspense out there
     if (!operations) throw new Error('unreachable')
 
+    const resolvedOperations = useMemo(
+      () =>
+        operations.map((operation) => ({
+          operation,
+          match: operatorMatcher ? getOperationMatchResult(operation, operatorMatcher.ownedOperators) : undefined,
+        })),
+      [operations, operatorMatcher],
+    )
+    const visibleOperations = useMemo(
+      () =>
+        operatorMatcher
+          ? resolvedOperations.filter(({ match }) => match && operatorMatcher.modes.includes(match.mode))
+          : resolvedOperations,
+      [operatorMatcher, resolvedOperations],
+    )
+    const autoLoadCount = useRef(0)
+
     useEffect(() => {
       onUpdate?.({ total })
     }, [total, onUpdate])
+
+    useEffect(() => {
+      autoLoadCount.current = 0
+    }, [operatorMatcher])
+
+    useEffect(() => {
+      if (
+        !operatorMatcher ||
+        visibleOperations.length > 0 ||
+        isReachingEnd ||
+        isValidating ||
+        autoLoadCount.current >= 2
+      ) {
+        return
+      }
+
+      autoLoadCount.current += 1
+      void setSize((size) => size + 1)
+    }, [isReachingEnd, isValidating, operatorMatcher, setSize, visibleOperations.length])
 
     const [selectedOperations, setSelectedOperations] = useState<Operation[]>([])
     const updateSelection = (add: Operation[], remove: Operation[]) => {
@@ -58,7 +96,7 @@ export const OperationList: ComponentType<OperationListProps> = withSuspensable(
           gridTemplateColumns: 'repeat(auto-fill, minmax(20rem, 1fr)',
         }}
       >
-        {operations.map((operation) => (
+        {visibleOperations.map(({ operation }) => (
           <NeoOperationCard
             operation={operation}
             key={operation.id}
@@ -70,7 +108,7 @@ export const OperationList: ComponentType<OperationListProps> = withSuspensable(
       </ul>
     ) : (
       <ul>
-        {operations.map((operation) => (
+        {visibleOperations.map(({ operation }) => (
           <OperationCard operation={operation} key={operation.id} />
         ))}
       </ul>
@@ -103,7 +141,11 @@ export const OperationList: ComponentType<OperationListProps> = withSuspensable(
             </details>
             <div className="absolute top-2 right-2 flex">
               <Tooltip content={t.components.OperationList.only_loaded_items} placement="top">
-                <Button minimal icon="tick" onClick={() => updateSelection(operations, [])}>
+                <Button
+                  minimal
+                  icon="tick"
+                  onClick={() => updateSelection(visibleOperations.map(({ operation }) => operation), [])}
+                >
                   {t.components.OperationList.select_all}
                 </Button>
               </Tooltip>
@@ -127,7 +169,7 @@ export const OperationList: ComponentType<OperationListProps> = withSuspensable(
 
         {items}
 
-        {isReachingEnd && operations.length === 0 && (
+        {isReachingEnd && visibleOperations.length === 0 && (
           <NonIdealState
             icon="slash"
             title={t.components.OperationList.no_jobs_found}
@@ -135,7 +177,7 @@ export const OperationList: ComponentType<OperationListProps> = withSuspensable(
           />
         )}
 
-        {isReachingEnd && operations.length !== 0 && (
+        {isReachingEnd && visibleOperations.length !== 0 && (
           <div className="mt-8 w-full tracking-wider text-center select-none text-slate-500">
             {t.components.OperationList.reached_bottom}
           </div>
@@ -156,6 +198,6 @@ export const OperationList: ComponentType<OperationListProps> = withSuspensable(
     )
   },
   {
-    retryOnChange: ['orderBy', 'keyword', 'levelKeyword', 'operator'],
+    retryOnChange: ['orderBy', 'keyword', 'levelKeyword', 'operator', 'operatorMatcher'],
   },
 )

--- a/src/components/Operations.tsx
+++ b/src/components/Operations.tsx
@@ -16,8 +16,10 @@ import { useTranslation } from '../i18n/i18n'
 import { CopilotType } from '../models/operation'
 import { LevelSelect } from './LevelSelect'
 import { OperatorFilter, useOperatorFilter } from './OperatorFilter'
+import { OperatorMatcher } from './OperatorMatcher'
 import { withSuspensable } from './Suspensable'
 import { UserFilter } from './UserFilter'
+import { OperatorMatcherFilter } from '../models/operatorMatcher'
 
 export const Operations: ComponentType = withSuspensable(() => {
   const t = useTranslation()
@@ -32,6 +34,7 @@ export const Operations: ComponentType = withSuspensable(() => {
   const [neoLayout, setNeoLayout] = useAtom(neoLayoutAtom)
   const [tab, setTab] = useState<'operation' | 'operationSet'>('operation')
   const [multiselect, setMultiselect] = useState(false)
+  const [operatorMatcher, setOperatorMatcher] = useState<OperatorMatcherFilter>()
 
   return (
     <>
@@ -182,6 +185,9 @@ export const Operations: ComponentType = withSuspensable(() => {
                 </ButtonGroup>
               </div>
             </div>
+            <div className="flex flex-wrap items-center gap-2 mt-2">
+              <OperatorMatcher onChange={setOperatorMatcher} />
+            </div>
           </>
         )}
 
@@ -232,6 +238,7 @@ export const Operations: ComponentType = withSuspensable(() => {
             {...queryParams}
             multiselect={multiselect}
             operator={operatorFilter.enabled ? operatorFilter : undefined}
+            operatorMatcher={operatorMatcher}
             // 按热度排序时列表前几页的变化不会太频繁，可以不刷新第一页，节省点流量
             revalidateFirstPage={queryParams.orderBy !== 'hot'}
           />

--- a/src/components/OperatorMatcher.tsx
+++ b/src/components/OperatorMatcher.tsx
@@ -1,0 +1,342 @@
+import {
+  Button,
+  ButtonGroup,
+  Callout,
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  H4,
+  InputGroup,
+  Switch,
+  Tag,
+} from '@blueprintjs/core'
+
+import { RESET } from 'jotai/vanilla/utils'
+import { useAtom } from 'jotai'
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  DEFAULT_OPERATOR_MATCH_MODES,
+  OperatorMatcherFilter,
+  OperatorMatchMode,
+  createOwnedOperatorMap,
+  hasOwnedOperatorDataChanged,
+  normalizeYituliuOwnedOperators,
+} from '../models/operatorMatcher'
+import { operatorMatcherSettingsAtom } from '../store/operatorMatcher'
+import { AppToaster } from './Toaster'
+import { Confirm } from './Confirm'
+import { useTranslation } from '../i18n/i18n'
+
+const YITULIU_OPERATOR_API_URL = 'https://backend.yituliu.cn/open-api/operator/info'
+const OPERATOR_DATA_STALE_AFTER_MS = 33 * 24 * 60 * 60 * 1000
+
+function isOperatorDataStale(lastChangedAt: string | undefined) {
+  if (!lastChangedAt) {
+    return false
+  }
+
+  const time = new Date(lastChangedAt).getTime()
+  return Number.isFinite(time) && Date.now() - time > OPERATOR_DATA_STALE_AFTER_MS
+}
+
+interface OpenApiResult {
+  code?: number
+  data?: unknown
+  message?: string
+}
+
+interface OperatorMatcherProps {
+  onChange: (matcher: OperatorMatcherFilter | undefined) => void
+}
+
+export const OperatorMatcher: FC<OperatorMatcherProps> = ({ onChange }) => {
+  const t = useTranslation()
+  const [settings, setSettings] = useAtom(operatorMatcherSettingsAtom)
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [token, setToken] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const autoSyncAttempted = useRef(false)
+
+  const closeDialog = () => {
+    setDialogOpen(false)
+    setToken('')
+    setError('')
+  }
+
+  const openDialog = () => {
+    setToken(settings.token)
+    setError('')
+    setDialogOpen(true)
+  }
+
+  const matcher = useMemo<OperatorMatcherFilter | undefined>(() => {
+    if (!settings.enabled || settings.ownedOperators.length === 0) {
+      return undefined
+    }
+
+    return {
+      modes: settings.modes,
+      ownedOperators: createOwnedOperatorMap(settings.ownedOperators),
+    }
+  }, [settings])
+
+  useEffect(() => {
+    onChange(matcher)
+  }, [matcher, onChange])
+
+  const syncOperators = useCallback(
+    async (
+      tokenToUse: string,
+      options: {
+        enableMatching: boolean
+        showError: boolean
+        showSuccess: boolean
+      },
+    ) => {
+      const normalizedToken = tokenToUse.trim()
+
+      if (!normalizedToken) {
+        if (options.showError) {
+          setError(t.components.OperatorMatcher.token_required)
+        }
+        return false
+      }
+
+      if (options.showError) {
+        setError('')
+      }
+
+      setLoading(true)
+
+      try {
+        const response = await fetch(YITULIU_OPERATOR_API_URL, {
+          headers: {
+            Authorization: normalizedToken,
+          },
+        })
+        const payload = (await response.json()) as OpenApiResult
+
+        if (!response.ok || payload.code !== 200) {
+          throw new Error(payload.message || t.components.OperatorMatcher.fetch_failed)
+        }
+
+        const operators = normalizeYituliuOwnedOperators(payload.data)
+
+        if (operators.length === 0) {
+          throw new Error(t.components.OperatorMatcher.no_operators)
+        }
+
+        setSettings((current) => {
+          const dataChanged = hasOwnedOperatorDataChanged(current.ownedOperators, operators)
+          const enableMatching = options.enableMatching ? true : current.enabled
+          const modes = current.modes.length > 0 ? current.modes : [...DEFAULT_OPERATOR_MATCH_MODES]
+          const shouldSetLastChangedAt = dataChanged || !current.lastChangedAt
+
+          if (
+            !dataChanged &&
+            !shouldSetLastChangedAt &&
+            current.enabled === enableMatching &&
+            current.token === normalizedToken &&
+            current.modes.length > 0
+          ) {
+            return current
+          }
+
+          return {
+            ...current,
+            enabled: enableMatching,
+            token: normalizedToken,
+            ownedOperators: dataChanged ? operators : current.ownedOperators,
+            modes,
+            ...(shouldSetLastChangedAt ? { lastChangedAt: new Date().toISOString() } : {}),
+          }
+        })
+
+        if (options.showSuccess) {
+          AppToaster.show({
+            intent: 'success',
+            message: t.components.OperatorMatcher.imported({
+              count: operators.length,
+            }),
+          })
+        }
+
+        return true
+      } catch (error) {
+        if (options.showError) {
+          setError(error instanceof Error ? error.message : t.components.OperatorMatcher.fetch_failed)
+        }
+        return false
+      } finally {
+        setLoading(false)
+      }
+    },
+    [setSettings, t],
+  )
+
+  useEffect(() => {
+    if (autoSyncAttempted.current || !settings.token) {
+      return
+    }
+
+    autoSyncAttempted.current = true
+    void syncOperators(settings.token, {
+      enableMatching: false,
+      showError: false,
+      showSuccess: false,
+    })
+  }, [settings.token, syncOperators])
+
+  const importOperators = async () => {
+    autoSyncAttempted.current = true
+    const imported = await syncOperators(token, {
+      enableMatching: true,
+      showError: true,
+      showSuccess: true,
+    })
+
+    if (imported) {
+      closeDialog()
+    }
+  }
+
+  const toggleMode = (mode: OperatorMatchMode) => {
+    if (settings.ownedOperators.length === 0) {
+      return
+    }
+
+    const modes = settings.modes.includes(mode)
+      ? settings.modes.filter((item) => item !== mode)
+      : [...settings.modes, mode]
+
+    if (modes.length === 0) {
+      return
+    }
+
+    setSettings((current) => ({ ...current, modes }))
+  }
+
+  const modeOptions: Array<{ mode: OperatorMatchMode; text: string }> = [
+    { mode: 'ready', text: t.components.OperatorMatcher.ready },
+    { mode: 'borrow', text: t.components.OperatorMatcher.borrow },
+    { mode: 'train', text: t.components.OperatorMatcher.train },
+    { mode: 'blocked', text: t.components.OperatorMatcher.blocked },
+  ]
+  const showStaleReminder = isOperatorDataStale(settings.lastChangedAt)
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center gap-1">
+        <Button
+          minimal
+          className="!px-3"
+          icon="cog"
+          active={settings.enabled && settings.ownedOperators.length > 0}
+          intent={settings.enabled && settings.ownedOperators.length > 0 ? 'primary' : 'none'}
+          onClick={openDialog}
+        >
+          {t.components.OperatorMatcher.match_operators}
+        </Button>
+        {settings.ownedOperators.length > 0 && (
+          <ButtonGroup>
+            {modeOptions.map(({ mode, text }) => (
+              <Button
+                key={mode}
+                active={settings.modes.includes(mode)}
+                disabled={!settings.enabled}
+                intent={settings.modes.includes(mode) ? 'primary' : 'none'}
+                onClick={() => toggleMode(mode)}
+              >
+                {text}
+              </Button>
+            ))}
+          </ButtonGroup>
+        )}
+        {showStaleReminder && (
+          <span className="ml-1 text-sm text-amber-700">{t.components.OperatorMatcher.stale_reminder}</span>
+        )}
+      </div>
+
+      <Dialog isOpen={dialogOpen} onClose={closeDialog} title={t.components.OperatorMatcher.dialog_title}>
+        <DialogBody>
+          <Callout className="mb-4" icon="info-sign">
+            {t.components.OperatorMatcher.token_help.jsx({
+              yituliu: (
+                <a href="https://ark.yituliu.cn/account/home" target="_blank" rel="noopener noreferrer">
+                  {t.links.yituliu_site}
+                </a>
+              ),
+            })}
+          </Callout>
+          {settings.ownedOperators.length > 0 && (
+            <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+              <Tag minimal intent={settings.enabled ? 'primary' : 'none'}>
+                {t.components.OperatorMatcher.imported_count({
+                  count: settings.ownedOperators.length,
+                })}
+              </Tag>
+            </div>
+          )}
+          <InputGroup
+            fill
+            large
+            type="text"
+            placeholder={t.components.OperatorMatcher.token_placeholder}
+            value={token}
+            onChange={(event) => setToken(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                void importOperators()
+              }
+            }}
+          />
+          {error && (
+            <Callout className="mt-3" intent="danger">
+              {error}
+            </Callout>
+          )}
+        </DialogBody>
+        <DialogFooter
+          actions={
+            <>
+              {settings.ownedOperators.length > 0 && (
+                <Confirm
+                  intent="danger"
+                  canOutsideClickCancel
+                  confirmButtonText={t.components.OperatorMatcher.clear_confirm}
+                  onConfirm={() => setSettings(RESET)}
+                  trigger={({ handleClick }) => (
+                    <Button minimal icon="trash" intent="danger" onClick={handleClick}>
+                      {t.components.OperatorMatcher.clear}
+                    </Button>
+                  )}
+                >
+                  <H4>{t.components.OperatorMatcher.clear_title}</H4>
+                  <p>{t.components.OperatorMatcher.clear_message}</p>
+                </Confirm>
+              )}
+              <Button intent="primary" icon="download" loading={loading} onClick={() => void importOperators()}>
+                {settings.ownedOperators.length > 0
+                  ? t.components.OperatorMatcher.sync
+                  : t.components.OperatorMatcher.import}
+              </Button>
+            </>
+          }
+        >
+          {settings.ownedOperators.length > 0 && (
+            <div>
+              <Switch
+                className="mb-0"
+                checked={settings.enabled}
+                label={t.components.OperatorMatcher.enabled}
+                onChange={(event) => setSettings((current) => ({ ...current, enabled: event.currentTarget.checked }))}
+              />
+            </div>
+          )}
+        </DialogFooter>
+      </Dialog>
+    </>
+  )
+}

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -3705,6 +3705,10 @@
         "cn": "干员组",
         "en": "Operator Group"
       },
+      "unnamed_group": {
+        "cn": "未命名分组",
+        "en": "Unnamed Group"
+      },
       "skill_number": {
         "cn": {
           "0": "不指定技能",

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -3420,6 +3420,92 @@
         "en": "Remember Selection"
       }
     },
+    "OperatorMatcher": {
+      "match_operators": {
+        "cn": "干员匹配设置",
+        "en": "Operator Match Settings"
+      },
+      "dialog_title": {
+        "cn": "干员匹配设置",
+        "en": "Operator Match Settings"
+      },
+      "token_help": {
+        "cn": "Token 会保存到当前浏览器的本地存储，仅用于直接向{{yituliu}}请求干员数据，不会发送至作业站。",
+        "en": "The token is stored in this browser and used only for direct operator-data requests to {{yituliu}}. It is not sent to PRTS Plus."
+      },
+      "token_placeholder": {
+        "cn": "输入一图流第三方 API Token",
+        "en": "Enter your Yituliu OpenAPI token"
+      },
+      "token_required": {
+        "cn": "请输入 Token",
+        "en": "Enter a token first"
+      },
+      "fetch_failed": {
+        "cn": "获取干员数据失败",
+        "en": "Failed to fetch operator data"
+      },
+      "no_operators": {
+        "cn": "未读取到可用于匹配的干员数据",
+        "en": "No usable operator data was returned"
+      },
+      "imported": {
+        "cn": "已导入 {{count}} 名干员",
+        "en": "Imported {{count}} operators"
+      },
+      "imported_count": {
+        "cn": "已导入{{count}}名干员数据",
+        "en": "Imported data for {{count}} operators"
+      },
+      "ready": {
+        "cn": "可以直接打",
+        "en": "Ready"
+      },
+      "borrow": {
+        "cn": "需要借干员",
+        "en": "Borrow"
+      },
+      "train": {
+        "cn": "需要提升练度",
+        "en": "Train"
+      },
+      "blocked": {
+        "cn": "干员不满足要求",
+        "en": "Blocked"
+      },
+      "enabled": {
+        "cn": "启用干员匹配",
+        "en": "Enable operator matching"
+      },
+      "clear": {
+        "cn": "清除本地数据",
+        "en": "Clear local data"
+      },
+      "clear_title": {
+        "cn": "清除干员匹配数据？",
+        "en": "Clear operator matching data?"
+      },
+      "clear_message": {
+        "cn": "这将删除本地保存的 Token、干员数据和匹配设置。",
+        "en": "This will delete the locally saved token, operator data, and matching settings."
+      },
+      "clear_confirm": {
+        "cn": "清除",
+        "en": "Clear"
+      },
+      "sync": {
+        "cn": "同步干员数据",
+        "en": "Sync operator data"
+      },
+      "stale_reminder": {
+        "cn": "干员数据超过 33 天未变动，建议确认一图流数据是否为最新。",
+        "en": "Operator data has not changed in over 33 days. Confirm that it is up to date in Yituliu."
+      },
+      "import": {
+        "cn": "导入",
+        "en": "Import"
+      }
+    },
     "OperatorSelect": {
       "no_matching_operators": {
         "cn": "没有匹配的干员",
@@ -4350,7 +4436,7 @@
       "en": "Theresa"
     },
     "yituliu_site": {
-      "cn": "一图流",
+      "cn": "明日方舟一图流",
       "en": "Yituliu"
     },
     "feedback": {

--- a/src/models/operatorMatcher.ts
+++ b/src/models/operatorMatcher.ts
@@ -1,0 +1,273 @@
+import { CopilotDocV1 } from './copilot.schema'
+import { Operation } from './operation'
+import { findOperatorById } from './operator'
+
+const MAX_LEVELS_BY_RARITY: Record<number, number[]> = {
+  0: [30, 0, 0],
+  1: [30, 0, 0],
+  2: [30, 0, 0],
+  3: [40, 55, 0],
+  4: [45, 60, 70],
+  5: [50, 70, 80],
+  6: [50, 80, 90],
+}
+
+export const OPERATOR_MATCH_MODES = ['ready', 'borrow', 'train', 'blocked'] as const
+export type OperatorMatchMode = (typeof OPERATOR_MATCH_MODES)[number]
+
+export const DEFAULT_OPERATOR_MATCH_MODES: OperatorMatchMode[] = ['ready', 'borrow', 'train']
+
+export interface OwnedOperator {
+  elite: number
+  level: number
+  mainSkillLevel?: number
+  masteryLevels: number[]
+  moduleLevels: Partial<Record<CopilotDocV1.Module, number>>
+  name: string
+  rarity: number
+}
+
+export interface OperatorMatcherFilter {
+  modes: OperatorMatchMode[]
+  ownedOperators: Map<string, OwnedOperator>
+}
+
+export interface OperationMatchResult {
+  missingSlots: string[]
+  mode: OperatorMatchMode
+  totalSlots: number
+  trainingSlots: string[]
+}
+
+type UnknownRecord = Record<string, unknown>
+
+function toNonNegativeInteger(value: unknown): number | undefined {
+  const number = Number(value)
+  return Number.isFinite(number) ? Math.max(0, Math.floor(number)) : undefined
+}
+
+function toRecord(value: unknown): UnknownRecord | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as UnknownRecord) : undefined
+}
+
+function normalizeName(name: string) {
+  return name.trim().replace(/\s+/g, '')
+}
+
+export function normalizeYituliuOwnedOperators(data: unknown): OwnedOperator[] {
+  if (!Array.isArray(data)) {
+    return []
+  }
+
+  return data.flatMap((value) => {
+    const record = toRecord(value)
+
+    if (!record) {
+      return []
+    }
+
+    const id = typeof record?.id === 'string' ? record.id : ''
+    const operator = id ? findOperatorById(id) : undefined
+    const level = toNonNegativeInteger(record?.level)
+
+    if (!operator || !level) {
+      return []
+    }
+
+    const masteryLevels = Array.isArray(record.skills)
+      ? record.skills.map((skill) => toNonNegativeInteger(toRecord(skill)?.level) ?? 0)
+      : []
+    const moduleLevels: Partial<Record<CopilotDocV1.Module, number>> = {}
+
+    if (Array.isArray(record.equips)) {
+      for (const equip of record.equips) {
+        const type = toRecord(equip)?.type
+        const level = toNonNegativeInteger(toRecord(equip)?.level)
+
+        if (typeof type === 'string' && level !== undefined && type in CopilotDocV1.Module) {
+          moduleLevels[CopilotDocV1.Module[type as keyof typeof CopilotDocV1.Module]] = level
+        }
+      }
+    }
+
+    return [
+      {
+        name: operator.name,
+        rarity: operator.rarity,
+        elite: toNonNegativeInteger(record.evolvePhase) ?? 0,
+        level,
+        mainSkillLevel: toNonNegativeInteger(record.mainSkillLevel),
+        masteryLevels,
+        moduleLevels,
+      },
+    ]
+  })
+}
+
+export function createOwnedOperatorMap(operators: OwnedOperator[]) {
+  return new Map(operators.map((operator) => [normalizeName(operator.name), operator]))
+}
+
+function getOwnedOperatorSnapshot(operators: OwnedOperator[]) {
+  return Array.from(createOwnedOperatorMap(operators).entries())
+    .sort(([firstName], [secondName]) => firstName.localeCompare(secondName))
+    .map(([name, operator]) => ({
+      name,
+      rarity: operator.rarity,
+      elite: operator.elite,
+      level: operator.level,
+      mainSkillLevel: operator.mainSkillLevel ?? null,
+      masteryLevels: operator.masteryLevels,
+      moduleLevels: Object.entries(operator.moduleLevels).sort(([firstModule], [secondModule]) => {
+        return Number(firstModule) - Number(secondModule)
+      }),
+    }))
+}
+
+export function hasOwnedOperatorDataChanged(previous: OwnedOperator[], next: OwnedOperator[]) {
+  return JSON.stringify(getOwnedOperatorSnapshot(previous)) !== JSON.stringify(getOwnedOperatorSnapshot(next))
+}
+
+function getProgressScore(rarity: number, elite: number, level: number) {
+  const maxLevels = MAX_LEVELS_BY_RARITY[rarity] ?? MAX_LEVELS_BY_RARITY[6]
+  let score = Math.max(1, level)
+
+  for (let index = 0; index < elite; index += 1) {
+    score += maxLevels[index] ?? 0
+  }
+
+  return score
+}
+
+function inferElite(rarity: number, level: number, elite: number | undefined) {
+  if (elite !== undefined) {
+    return elite
+  }
+
+  const maxLevels = MAX_LEVELS_BY_RARITY[rarity] ?? MAX_LEVELS_BY_RARITY[6]
+  let inferredElite = 0
+
+  while (inferredElite < maxLevels.length - 1 && level > (maxLevels[inferredElite] ?? 0)) {
+    inferredElite += 1
+  }
+
+  return inferredElite
+}
+
+function isRequirementMet(requirement: CopilotDocV1.Operator, ownedOperator: OwnedOperator | undefined) {
+  if (!ownedOperator) {
+    return false
+  }
+
+  const requirements = requirement.requirements
+
+  if (!requirements) {
+    return true
+  }
+
+  if (requirements.elite !== undefined || requirements.level !== undefined) {
+    const requiredLevel = requirements.level ?? 1
+    const requiredElite = inferElite(ownedOperator.rarity, requiredLevel, requirements.elite)
+    const ownedScore = getProgressScore(ownedOperator.rarity, ownedOperator.elite, ownedOperator.level)
+    const requiredScore = getProgressScore(ownedOperator.rarity, requiredElite, requiredLevel)
+
+    if (ownedScore < requiredScore) {
+      return false
+    }
+  }
+
+  if (requirements.skillLevel !== undefined) {
+    if (requirements.skillLevel >= 8) {
+      const skillIndex = requirement.skill
+      const masteryLevel = skillIndex ? ownedOperator.masteryLevels[skillIndex - 1] : undefined
+
+      if (masteryLevel === undefined || masteryLevel < requirements.skillLevel - 7) {
+        return false
+      }
+    } else if ((ownedOperator.mainSkillLevel ?? 0) < requirements.skillLevel) {
+      return false
+    }
+  }
+
+  if (requirements.module !== undefined && requirements.module > CopilotDocV1.Module.Original) {
+    if ((ownedOperator.moduleLevels[requirements.module] ?? 0) < 1) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function evaluateGroup(group: CopilotDocV1.Group, ownedOperators: Map<string, OwnedOperator>) {
+  const candidates = group.opers ?? []
+  const ownedCandidates = candidates.filter((candidate) => ownedOperators.has(normalizeName(candidate.name)))
+
+  if (
+    ownedCandidates.some((candidate) => isRequirementMet(candidate, ownedOperators.get(normalizeName(candidate.name))))
+  ) {
+    return 'ready'
+  }
+
+  return ownedCandidates.length > 0 ? 'train' : 'missing'
+}
+
+export function getOperationMatchResult(
+  operation: Operation,
+  ownedOperators: Map<string, OwnedOperator>,
+): OperationMatchResult {
+  const missingSlots: string[] = []
+  const trainingSlots: string[] = []
+  const operators = operation.parsedContent.opers ?? []
+  const groups = operation.parsedContent.groups ?? []
+
+  for (const operator of operators) {
+    const ownedOperator = ownedOperators.get(normalizeName(operator.name))
+
+    if (!ownedOperator) {
+      missingSlots.push(operator.name)
+    } else if (!isRequirementMet(operator, ownedOperator)) {
+      trainingSlots.push(operator.name)
+    }
+  }
+
+  for (const group of groups) {
+    const readiness = evaluateGroup(group, ownedOperators)
+
+    if (readiness === 'missing') {
+      missingSlots.push(group.name || group.opers?.map((operator) => operator.name).join(' / ') || '未命名分组')
+    } else if (readiness === 'train') {
+      trainingSlots.push(group.name || group.opers?.map((operator) => operator.name).join(' / ') || '未命名分组')
+    }
+  }
+
+  const totalSlots = operators.length + groups.length
+
+  if (totalSlots > 13 || missingSlots.length >= 2) {
+    return { mode: 'blocked', missingSlots, trainingSlots, totalSlots }
+  }
+
+  if (missingSlots.length === 1) {
+    return {
+      mode: trainingSlots.length > 0 ? 'train' : 'borrow',
+      missingSlots,
+      trainingSlots,
+      totalSlots,
+    }
+  }
+
+  if (trainingSlots.length === 0) {
+    return {
+      mode: totalSlots === 13 ? 'borrow' : 'ready',
+      missingSlots,
+      trainingSlots,
+      totalSlots,
+    }
+  }
+
+  return {
+    mode: trainingSlots.length === 1 && totalSlots < 13 ? 'borrow' : 'train',
+    missingSlots,
+    trainingSlots,
+    totalSlots,
+  }
+}

--- a/src/models/operatorMatcher.ts
+++ b/src/models/operatorMatcher.ts
@@ -1,3 +1,5 @@
+import { i18n } from '../i18n/i18n'
+
 import { CopilotDocV1 } from './copilot.schema'
 import { Operation } from './operation'
 import { findOperatorById } from './operator'
@@ -198,6 +200,14 @@ function isRequirementMet(requirement: CopilotDocV1.Operator, ownedOperator: Own
   return true
 }
 
+function getGroupDisplayName(group: CopilotDocV1.Group) {
+  return (
+    group.name ||
+    group.opers?.map((operator) => operator.name).join(' / ') ||
+    i18n.models.operator.unnamed_group
+  )
+}
+
 function evaluateGroup(group: CopilotDocV1.Group, ownedOperators: Map<string, OwnedOperator>) {
   const candidates = group.opers ?? []
   const ownedCandidates = candidates.filter((candidate) => ownedOperators.has(normalizeName(candidate.name)))
@@ -234,9 +244,9 @@ export function getOperationMatchResult(
     const readiness = evaluateGroup(group, ownedOperators)
 
     if (readiness === 'missing') {
-      missingSlots.push(group.name || group.opers?.map((operator) => operator.name).join(' / ') || '未命名分组')
+      missingSlots.push(getGroupDisplayName(group))
     } else if (readiness === 'train') {
-      trainingSlots.push(group.name || group.opers?.map((operator) => operator.name).join(' / ') || '未命名分组')
+      trainingSlots.push(getGroupDisplayName(group))
     }
   }
 

--- a/src/store/operatorMatcher.ts
+++ b/src/store/operatorMatcher.ts
@@ -1,0 +1,25 @@
+import { atomWithStorage } from 'jotai/utils'
+
+import { DEFAULT_OPERATOR_MATCH_MODES, OperatorMatchMode, OwnedOperator } from '../models/operatorMatcher'
+
+export interface OperatorMatcherSettings {
+  enabled: boolean
+  lastChangedAt?: string
+  modes: OperatorMatchMode[]
+  ownedOperators: OwnedOperator[]
+  token: string
+}
+
+export const DEFAULT_OPERATOR_MATCHER_SETTINGS: OperatorMatcherSettings = {
+  enabled: false,
+  modes: [...DEFAULT_OPERATOR_MATCH_MODES],
+  ownedOperators: [],
+  token: '',
+}
+
+export const operatorMatcherSettingsAtom = atomWithStorage<OperatorMatcherSettings>(
+  'zoot-plus-operator-matcher',
+  DEFAULT_OPERATOR_MATCHER_SETTINGS,
+  undefined,
+  { getOnInit: true },
+)


### PR DESCRIPTION
增加了通过一图流token导入干员的入口，导入后可以筛选符合自己box的作业

## Summary by Sourcery

集成操作员匹配功能，通过用户使用 Yituliu 令牌导入的自有操作员来筛选作业。

新功能：
- 添加 `OperatorMatcher` UI 组件，使用户可以使用 API 令牌从 Yituliu 导入并管理自有操作员，并为作业筛选选择不同的匹配模式。
- 引入操作员匹配逻辑，将每个作业与用户的自有操作员进行评估，并将作业划分为不同的准备模式（已就绪、可借用、需训练、已阻塞）。
- 允许按操作员匹配结果筛选作业列表，使用户能够专注于与当前箱子配置兼容的作业，并在需要时自动加载更多页面。

增强：
- 将操作员匹配器设置（包括令牌、自有操作员、启用状态和匹配模式）持久化到本地存储，以便重复使用。
- 更新作业页面布局，将操作员匹配器控件与现有筛选器一起展示，并确保选择状态和空列表提示与筛选后的作业列表保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate an operator matching feature that filters operations based on the user’s owned operators imported via a Yituliu token.

New Features:
- Add an OperatorMatcher UI component that lets users import and manage owned operators from Yituliu using an API token and choose matching modes for job filtering.
- Introduce operator matching logic to evaluate each operation against the user’s owned operators and classify jobs into readiness modes (ready, borrow, train, blocked).
- Allow the operations list to be filtered by operator match results so users can focus on jobs compatible with their current box, including auto-loading more pages when needed.

Enhancements:
- Persist operator matcher settings, including token, owned operators, enabled state, and match modes, in local storage for reuse.
- Update the operations page layout to surface the operator matcher controls alongside existing filters and ensure selection and empty-state messages respect the filtered operation list.

</details>