### PR TITLE
feat: add operator matching to job sets

### DIFF
--- a/src/apis/operation.ts
+++ b/src/apis/operation.ts
@@ -11,6 +11,10 @@ import { useSWRRefresh } from 'utils/swr'
 
 export type OrderBy = 'views' | 'hot' | 'id'
 
+const OPERATION_DETAILS_BATCH_SIZE = 50
+const OPERATION_DETAILS_CONCURRENCY = 3
+const operationDetailsCache = new Map<number, Operation | null>()
+
 export interface OperatorFilterParams {
   included: string[]
   excluded: string[]
@@ -184,11 +188,50 @@ export async function getOperation(req: { id: number }): Promise<Operation> {
   }
 }
 
-export async function createOperation(req: {
-  content: string
-  status: CopilotSetStatus
-  type: CopilotType
-}) {
+export async function getOperationsByIds(operationIds: number[]): Promise<Operation[]> {
+  const uniqueIds = Array.from(new Set(operationIds))
+  const missingIds = uniqueIds.filter((id) => !operationDetailsCache.has(id))
+  const batches = Array.from({ length: Math.ceil(missingIds.length / OPERATION_DETAILS_BATCH_SIZE) }, (_, index) =>
+    missingIds.slice(index * OPERATION_DETAILS_BATCH_SIZE, (index + 1) * OPERATION_DETAILS_BATCH_SIZE),
+  )
+  let nextBatchIndex = 0
+
+  await Promise.all(
+    Array.from({ length: Math.min(OPERATION_DETAILS_CONCURRENCY, batches.length) }, async () => {
+      while (nextBatchIndex < batches.length) {
+        const batch = batches[nextBatchIndex++]
+        const res = await new OperationApi({
+          sendToken: 'optional',
+          requireData: true,
+        }).queriesCopilot({
+          page: 1,
+          limit: batch.length,
+          copilotIds: batch,
+        })
+        const operations = res.data.data.map((operation) => ({
+          ...operation,
+          parsedContent: toCopilotOperation(operation),
+        }))
+
+        for (const operation of operations) {
+          operationDetailsCache.set(operation.id, operation)
+        }
+        for (const id of batch) {
+          if (!operationDetailsCache.has(id)) {
+            operationDetailsCache.set(id, null)
+          }
+        }
+      }
+    }),
+  )
+
+  return uniqueIds.flatMap((id) => {
+    const operation = operationDetailsCache.get(id)
+    return operation ? [operation] : []
+  })
+}
+
+export async function createOperation(req: { content: string; status: CopilotSetStatus; type: CopilotType }) {
   return (await new OperationApi().uploadCopilot({ uploadCopilotRequest: { ...req } })).data
 }
 

--- a/src/components/OperationSetList.tsx
+++ b/src/components/OperationSetList.tsx
@@ -1,21 +1,25 @@
-import { Button, NonIdealState } from '@blueprintjs/core'
+import { Button, NonIdealState, Spinner } from '@blueprintjs/core'
 
+import { getOperationsByIds } from 'apis/operation'
 import { UseOperationSetsParams, useOperationSetSearch } from 'apis/operation-set'
 import { useAtomValue } from 'jotai'
-import { ComponentType, ReactNode, useEffect } from 'react'
+import { ComponentType, ReactNode, useEffect, useMemo, useRef } from 'react'
+import useSWR from 'swr'
 
 import { neoLayoutAtom } from 'store/pref'
 
 import { useTranslation } from '../i18n/i18n'
+import { OperatorMatcherFilter, getOperationSetMatchResult } from '../models/operatorMatcher'
 import { NeoOperationSetCard, OperationSetCard } from './OperationSetCard'
 import { withSuspensable } from './Suspensable'
 
 interface OperationSetListProps extends UseOperationSetsParams {
   onUpdate?: (params: { total: number }) => void
+  operatorMatcher?: OperatorMatcherFilter
 }
 
 export const OperationSetList: ComponentType<OperationSetListProps> = withSuspensable(
-  ({ onUpdate, ...params }) => {
+  ({ onUpdate, operatorMatcher, ...params }) => {
     const t = useTranslation()
     const neoLayout = useAtomValue(neoLayoutAtom)
 
@@ -27,9 +31,75 @@ export const OperationSetList: ComponentType<OperationSetListProps> = withSuspen
     // make TS happy: we got Suspense out there
     if (!operationSets) throw new Error('unreachable')
 
+    const operationIds = useMemo(
+      () => Array.from(new Set(operationSets.flatMap((operationSet) => operationSet.copilotIds))),
+      [operationSets],
+    )
+    const {
+      data: operations,
+      error: matchingError,
+      isLoading: isMatching,
+    } = useSWR(
+      operatorMatcher ? (['operation-set-matcher-operations', operationIds] as const) : null,
+      ([, ids]) => getOperationsByIds(ids),
+      {
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+      },
+    )
+
+    if (matchingError) throw matchingError
+
+    const visibleOperationSets = useMemo(() => {
+      if (!operatorMatcher) {
+        return operationSets
+      }
+      if (!operations) {
+        return []
+      }
+
+      const operationsById = new Map(operations.map((operation) => [operation.id, operation]))
+
+      return operationSets.filter((operationSet) => {
+        const match = getOperationSetMatchResult(
+          operationSet.copilotIds,
+          operationsById,
+          operatorMatcher.ownedOperators,
+        )
+        return operatorMatcher.modes.includes(match.mode)
+      })
+    }, [operationSets, operations, operatorMatcher])
+    const autoLoadCount = useRef(0)
+    const matcherQueryKey = JSON.stringify({
+      keyword: params.keyword,
+      creatorId: params.creatorId,
+      onlyFollowing: params.onlyFollowing,
+      descending: params.descending,
+    })
+
     useEffect(() => {
       onUpdate?.({ total })
     }, [total, onUpdate])
+
+    useEffect(() => {
+      autoLoadCount.current = 0
+    }, [operatorMatcher, matcherQueryKey])
+
+    useEffect(() => {
+      if (
+        !operatorMatcher ||
+        isMatching ||
+        visibleOperationSets.length > 0 ||
+        isReachingEnd ||
+        isValidating ||
+        autoLoadCount.current >= 2
+      ) {
+        return
+      }
+
+      autoLoadCount.current += 1
+      void setSize((size) => size + 1)
+    }, [isMatching, isReachingEnd, isValidating, operatorMatcher, setSize, visibleOperationSets.length])
 
     const items: ReactNode = neoLayout ? (
       <div
@@ -38,19 +108,24 @@ export const OperationSetList: ComponentType<OperationSetListProps> = withSuspen
           gridTemplateColumns: 'repeat(auto-fill, minmax(20rem, 1fr)',
         }}
       >
-        {operationSets?.map((operationSet) => (
+        {visibleOperationSets.map((operationSet) => (
           <NeoOperationSetCard operationSet={operationSet} key={operationSet.id} />
         ))}
       </div>
     ) : (
-      operationSets.map((operationSet) => <OperationSetCard operationSet={operationSet} key={operationSet.id} />)
+      visibleOperationSets.map((operationSet) => <OperationSetCard operationSet={operationSet} key={operationSet.id} />)
     )
 
     return (
       <>
+        {isMatching && (
+          <div className="flex justify-center py-6">
+            <Spinner size={20} />
+          </div>
+        )}
         {items}
 
-        {isReachingEnd && operationSets.length === 0 && (
+        {isReachingEnd && !isMatching && visibleOperationSets.length === 0 && (
           <NonIdealState
             icon="slash"
             title={t.components.OperationSetList.no_job_sets_found}
@@ -58,7 +133,7 @@ export const OperationSetList: ComponentType<OperationSetListProps> = withSuspen
           />
         )}
 
-        {isReachingEnd && operationSets.length !== 0 && (
+        {isReachingEnd && !isMatching && visibleOperationSets.length !== 0 && (
           <div className="mt-8 w-full tracking-wider text-center select-none text-slate-500">
             {t.components.OperationSetList.reached_bottom}
           </div>
@@ -66,7 +141,8 @@ export const OperationSetList: ComponentType<OperationSetListProps> = withSuspen
 
         {!isReachingEnd && (
           <Button
-            loading={isValidating}
+            disabled={isMatching}
+            loading={isValidating || isMatching}
             text={t.components.OperationSetList.load_more}
             icon="more"
             className="mt-2"
@@ -79,6 +155,6 @@ export const OperationSetList: ComponentType<OperationSetListProps> = withSuspen
     )
   },
   {
-    retryOnChange: ['keyword'],
+    retryOnChange: ['keyword', 'operatorMatcher'],
   },
 )

--- a/src/components/Operations.tsx
+++ b/src/components/Operations.tsx
@@ -185,9 +185,6 @@ export const Operations: ComponentType = withSuspensable(() => {
                 </ButtonGroup>
               </div>
             </div>
-            <div className="flex flex-wrap items-center gap-2 mt-2">
-              <OperatorMatcher onChange={setOperatorMatcher} />
-            </div>
           </>
         )}
 
@@ -230,6 +227,9 @@ export const Operations: ComponentType = withSuspensable(() => {
             />
           </div>
         )}
+        <div className="flex flex-wrap items-center gap-2 mt-2">
+          <OperatorMatcher onChange={setOperatorMatcher} />
+        </div>
       </Card>
 
       <div className="tabular-nums">
@@ -243,7 +243,9 @@ export const Operations: ComponentType = withSuspensable(() => {
             revalidateFirstPage={queryParams.orderBy !== 'hot'}
           />
         )}
-        {tab === 'operationSet' && <OperationSetList {...queryParams} creatorId={queryParams.uploaderId} />}
+        {tab === 'operationSet' && (
+          <OperationSetList {...queryParams} creatorId={queryParams.uploaderId} operatorMatcher={operatorMatcher} />
+        )}
       </div>
     </>
   )

--- a/src/models/operatorMatcher.ts
+++ b/src/models/operatorMatcher.ts
@@ -41,6 +41,17 @@ export interface OperationMatchResult {
   trainingSlots: string[]
 }
 
+export interface OperationSetMatchResult {
+  mode: OperatorMatchMode
+}
+
+const MATCH_MODE_PRIORITY: Record<OperatorMatchMode, number> = {
+  ready: 0,
+  borrow: 1,
+  train: 2,
+  blocked: 3,
+}
+
 type UnknownRecord = Record<string, unknown>
 
 function toNonNegativeInteger(value: unknown): number | undefined {
@@ -280,4 +291,27 @@ export function getOperationMatchResult(
     trainingSlots,
     totalSlots,
   }
+}
+
+export function getOperationSetMatchResult(
+  operationIds: number[],
+  operationsById: Map<number, Operation>,
+  ownedOperators: Map<string, OwnedOperator>,
+): OperationSetMatchResult {
+  if (operationIds.length === 0) {
+    return { mode: 'blocked' }
+  }
+
+  let mode: OperatorMatchMode = 'ready'
+
+  for (const operationId of operationIds) {
+    const operation = operationsById.get(operationId)
+    const operationMode = operation ? getOperationMatchResult(operation, ownedOperators).mode : 'blocked'
+
+    if (MATCH_MODE_PRIORITY[operationMode] > MATCH_MODE_PRIORITY[mode]) {
+      mode = operationMode
+    }
+  }
+
+  return { mode }
 }


### PR DESCRIPTION
## 变更说明

给作业集搜索也加上干员匹配功能。

- 会检查作业集里的所有子作业，最终按其中最难完成的那个作业来判断作业集状态。
- 如果有子作业数据缺失或无法访问，作业集会按不可执行处理，避免出现误判。

## Summary by Sourcery

在作业集搜索中加入基于运算符的匹配与过滤，并将其集成到运营页面中。

新功能：
- 在列出作业集时支持运算符匹配器过滤，包括按“匹配难度最高的子作业”来评估每个作业集。
- 提供一个批量且带缓存的 API，用于按 ID 加载多个操作详情，以便在不同作业集之间进行匹配器评估。

改进：
- 当运算符匹配导致当前已加载结果全部被隐藏时，自动加载更多作业集页面（有一个小的上限），并在匹配进行中显示加载指示（spinner）。
- 在计算运算符匹配状态时，将缺失或无法访问子作业数据的作业集视为不可运行。
- 调整作业集列表的重试行为，当运算符匹配器设置发生变化时进行刷新。
- 重新定位运算符匹配器控件，使其在单个作业和作业集上都能一致地生效。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add operator-based matching and filtering to job set search and integrate it into the operations page.

New Features:
- Support operator matcher filtering when listing job sets, including evaluating each job set by the hardest matching sub-job.
- Provide a batched, cached API to load multiple operation details by ID for matcher evaluation across job sets.

Enhancements:
- Auto-load additional job set pages when operator matching hides all currently loaded results, up to a small limit, and show a spinner while matching is in progress.
- Treat job sets with missing or inaccessible sub-job data as non-runnable when computing operator match status.
- Adjust retry behavior of the job set list to refresh when operator matcher settings change.
- Reposition the operator matcher control so it applies consistently across both individual jobs and job sets.

</details>