### PR TITLE
Feat/operator requirements

### DIFF
--- a/src/components/editor/NumericInput2.tsx
+++ b/src/components/editor/NumericInput2.tsx
@@ -12,6 +12,13 @@ export interface NumericInput2Props extends MixedNumericInputProps {
   intOnly?: boolean
   onWheelFocused?: (e: React.WheelEvent<HTMLInputElement>) => void
   wheelStepSize?: number
+
+  /**
+   * 当用户输入非数字字符时，是否触发 onValueChange 并传入 NaN 作为数值。
+   * 该选项不影响清空输入框的行为，清空输入框时始终会触发 onValueChange 并传入 NaN。
+   * @default false
+   */
+  emitNaNString?: boolean
 }
 
 export const NumericInput2 = ({
@@ -19,6 +26,7 @@ export const NumericInput2 = ({
   min,
   max,
   minorStepSize,
+  emitNaNString,
   value,
   onValueChange,
   onFocus,
@@ -121,6 +129,9 @@ export const NumericInput2 = ({
         num = parseFloat(str)
 
         if (Number.isNaN(num) || !Number.isFinite(num)) {
+          if (emitNaNString) {
+            onValueChange?.(NaN, str, inputEl)
+          }
           return
         }
 

--- a/src/components/editor2/OperatorPresetSettings.tsx
+++ b/src/components/editor2/OperatorPresetSettings.tsx
@@ -1,27 +1,18 @@
 import { Button, ButtonProps, Dialog, DialogBody, FormGroup } from '@blueprintjs/core'
 import { useAtom } from 'jotai'
 import { Fragment, useState } from 'react'
-import { useTranslation } from '../../../i18n/i18n'
-import { getDefaultRequirements } from '../../../models/operator'
-import { editorAtoms } from '../editor-state'
-import { OperatorLevelEdit } from './OperatorItem'
+import { useTranslation } from '../../i18n/i18n'
+import { getDefaultRequirements } from '../../models/operator'
+import { editorAtoms } from './editor-state'
+import { OperatorLevelEdit } from './operator/OperatorItem'
 
-export interface CustomOperatorDefaults {
-  byRarity: Record<number, CustomOperatorDefaultsPerRarity>
-}
+interface OperatorPresetSettingsProps extends ButtonProps {}
 
-interface CustomOperatorDefaultsPerRarity {
-  level: number
-  elite: number
-}
-
-interface OperatorDefaultsSettingsProps extends ButtonProps {}
-
-export const OperatorDefaultsSettings = (props: OperatorDefaultsSettingsProps) => {
+export const OperatorPresetSettings = (props: OperatorPresetSettingsProps) => {
   const t = useTranslation()
   const [isOpen, setIsOpen] = useState(false)
   const [config, setConfig] = useAtom(editorAtoms.config)
-  const byRarity = config.operatorDefaults?.byRarity ?? {}
+  const byRarity = config.operatorPreset?.byRarity ?? {}
 
   return (
     <>
@@ -49,7 +40,7 @@ export const OperatorDefaultsSettings = (props: OperatorDefaultsSettingsProps) =
                     elite={byRarity[rarity]?.elite ?? getDefaultRequirements(rarity).elite}
                     onChange={({ level, elite }) => {
                       setConfig({
-                        operatorDefaults: {
+                        operatorPreset: {
                           byRarity: {
                             ...byRarity,
                             [rarity]: { level, elite },
@@ -68,7 +59,7 @@ export const OperatorDefaultsSettings = (props: OperatorDefaultsSettingsProps) =
             intent="danger"
             text={t.components.editor2.Settings.reset_to_default}
             onClick={() => {
-              setConfig({ operatorDefaults: undefined })
+              setConfig({ operatorPreset: undefined })
             }}
           />
         </DialogBody>

--- a/src/components/editor2/OperatorPresetSettings.tsx
+++ b/src/components/editor2/OperatorPresetSettings.tsx
@@ -23,9 +23,9 @@ export const OperatorPresetSettings = (props: OperatorPresetSettingsProps) => {
         text={t.components.editor2.Settings.edit}
       />
 
-      <Dialog isOpen={isOpen} onClose={() => setIsOpen(false)} title={t.components.editor2.Settings.operator_defaults}>
+      <Dialog isOpen={isOpen} onClose={() => setIsOpen(false)} title={t.components.editor2.Settings.operator_presets}>
         <DialogBody>
-          <FormGroup label={t.components.editor2.Settings.defaults_when_adding}>
+          <FormGroup label={t.components.editor2.Settings.presets_when_adding}>
             <div className="grid [grid-template-columns:repeat(2,minmax(0,auto))] gap-2 justify-start items-center">
               {[6, 5, 4, 3, 2, 1, 0].map((rarity) => (
                 <Fragment key={rarity}>

--- a/src/components/editor2/Settings.tsx
+++ b/src/components/editor2/Settings.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react'
 import { useTranslation } from '../../i18n/i18n'
 import { NumericInput2 } from '../editor/NumericInput2'
 import { editorAtoms } from './editor-state'
+import { OperatorDefaultsSettings } from './operator/CustomDefaults'
 
 interface SettingsProps extends ButtonProps {}
 
@@ -20,22 +21,26 @@ export const Settings = (props: SettingsProps) => {
 
       <Dialog isOpen={isOpen} onClose={() => setIsOpen(false)} title={t.components.editor2.Settings.title}>
         <DialogBody>
-          <Switch
-            checked={config.showLinkerButtons}
-            label={t.components.editor2.Settings.show_linker_buttons}
-            onChange={(e) => setConfig({ showLinkerButtons: e.currentTarget.checked })}
-          />
-          <Switch
-            checked={config.toggleSelectorPanel}
-            label={t.components.editor2.Settings.auto_toggle_selector_panel}
-            onChange={(e) => setConfig({ toggleSelectorPanel: e.currentTarget.checked })}
-          />
-          <Switch
-            checked={config.showErrorsByDefault}
-            label={t.components.editor2.Settings.show_errors_by_default}
-            onChange={(e) => setConfig({ showErrorsByDefault: e.currentTarget.checked })}
-          />
-
+          <FormGroup label={t.components.editor2.Settings.ui}>
+            <Switch
+              checked={config.showLinkerButtons}
+              label={t.components.editor2.Settings.show_linker_buttons}
+              onChange={(e) => setConfig({ showLinkerButtons: e.currentTarget.checked })}
+            />
+            <Switch
+              checked={config.toggleSelectorPanel}
+              label={t.components.editor2.Settings.auto_toggle_selector_panel}
+              onChange={(e) => setConfig({ toggleSelectorPanel: e.currentTarget.checked })}
+            />
+            <Switch
+              checked={config.showErrorsByDefault}
+              label={t.components.editor2.Settings.show_errors_by_default}
+              onChange={(e) => setConfig({ showErrorsByDefault: e.currentTarget.checked })}
+            />
+          </FormGroup>
+          <FormGroup label={t.components.editor2.Settings.operator_defaults}>
+            <OperatorDefaultsSettings />
+          </FormGroup>
           <FormGroup
             label={t.components.editor2.Settings.history_limit}
             helperText={t.components.editor2.Settings.history_limit_note}

--- a/src/components/editor2/Settings.tsx
+++ b/src/components/editor2/Settings.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react'
 import { useTranslation } from '../../i18n/i18n'
 import { NumericInput2 } from '../editor/NumericInput2'
 import { editorAtoms } from './editor-state'
-import { OperatorDefaultsSettings } from './operator/CustomDefaults'
+import { OperatorPresetSettings } from './OperatorPresetSettings'
 
 interface SettingsProps extends ButtonProps {}
 
@@ -39,7 +39,7 @@ export const Settings = (props: SettingsProps) => {
             />
           </FormGroup>
           <FormGroup label={t.components.editor2.Settings.operator_defaults}>
-            <OperatorDefaultsSettings />
+            <OperatorPresetSettings />
           </FormGroup>
           <FormGroup
             label={t.components.editor2.Settings.history_limit}

--- a/src/components/editor2/Settings.tsx
+++ b/src/components/editor2/Settings.tsx
@@ -38,7 +38,7 @@ export const Settings = (props: SettingsProps) => {
               onChange={(e) => setConfig({ showErrorsByDefault: e.currentTarget.checked })}
             />
           </FormGroup>
-          <FormGroup label={t.components.editor2.Settings.operator_defaults}>
+          <FormGroup label={t.components.editor2.Settings.operator_presets}>
             <OperatorPresetSettings />
           </FormGroup>
           <FormGroup

--- a/src/components/editor2/editor-state.ts
+++ b/src/components/editor2/editor-state.ts
@@ -8,6 +8,7 @@ import { CopilotDocV1 } from '../../models/copilot.schema'
 import { CopilotType } from '../../models/operation'
 import { PartialDeep } from '../../utils/partial-deep'
 import { createHistoryAtom, useHistoryEdit } from './history'
+import type { CustomOperatorDefaults } from './operator/CustomDefaults'
 import { WithId, WithPartialCoordinates, toEditorOperation } from './reconciliation'
 import { ZodIssue, operationLooseSchema } from './validation/schema'
 import { EntityIssue } from './validation/validation'
@@ -176,6 +177,7 @@ interface EditorConfig {
   toggleSelectorPanel: boolean
   historyLimit: number
   showErrorsByDefault: boolean
+  operatorDefaults?: CustomOperatorDefaults
 }
 const defaultConfig: EditorConfig = {
   showLinkerButtons: false,
@@ -210,6 +212,9 @@ const configAtom = atom(
     }
   },
 )
+export function getEditorConfig() {
+  return getDefaultStore().get(localConfigAtom)
+}
 
 const editorGlobalErrorsAtom = atom<ZodIssue[]>([])
 const editorEntityErrorsAtom = atom<Record<string, EntityIssue[]>>({})

--- a/src/components/editor2/editor-state.ts
+++ b/src/components/editor2/editor-state.ts
@@ -8,7 +8,6 @@ import { CopilotDocV1 } from '../../models/copilot.schema'
 import { CopilotType } from '../../models/operation'
 import { PartialDeep } from '../../utils/partial-deep'
 import { createHistoryAtom, useHistoryEdit } from './history'
-import type { CustomOperatorDefaults } from './operator/CustomDefaults'
 import { WithId, WithPartialCoordinates, toEditorOperation } from './reconciliation'
 import { ZodIssue, operationLooseSchema } from './validation/schema'
 import { EntityIssue } from './validation/validation'
@@ -177,7 +176,14 @@ interface EditorConfig {
   toggleSelectorPanel: boolean
   historyLimit: number
   showErrorsByDefault: boolean
-  operatorDefaults?: CustomOperatorDefaults
+  operatorPreset?: OperatorPreset
+}
+export interface OperatorPreset {
+  byRarity: Record<number, OperatorPresetPerRarity>
+}
+interface OperatorPresetPerRarity {
+  level: number
+  elite: number
 }
 const defaultConfig: EditorConfig = {
   showLinkerButtons: false,

--- a/src/components/editor2/operator/CustomDefaults.tsx
+++ b/src/components/editor2/operator/CustomDefaults.tsx
@@ -1,0 +1,78 @@
+import { Button, ButtonProps, Dialog, DialogBody, FormGroup } from '@blueprintjs/core'
+import { useAtom } from 'jotai'
+import { Fragment, useState } from 'react'
+import { useTranslation } from '../../../i18n/i18n'
+import { getDefaultRequirements } from '../../../models/operator'
+import { editorAtoms } from '../editor-state'
+import { OperatorLevelEdit } from './OperatorItem'
+
+export interface CustomOperatorDefaults {
+  byRarity: Record<number, CustomOperatorDefaultsPerRarity>
+}
+
+interface CustomOperatorDefaultsPerRarity {
+  level: number
+  elite: number
+}
+
+interface OperatorDefaultsSettingsProps extends ButtonProps {}
+
+export const OperatorDefaultsSettings = (props: OperatorDefaultsSettingsProps) => {
+  const t = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+  const [config, setConfig] = useAtom(editorAtoms.config)
+  const byRarity = config.operatorDefaults?.byRarity ?? {}
+
+  return (
+    <>
+      <Button
+        endIcon="caret-right"
+        {...props}
+        onClick={() => setIsOpen(true)}
+        text={t.components.editor2.Settings.edit}
+      />
+
+      <Dialog isOpen={isOpen} onClose={() => setIsOpen(false)} title={t.components.editor2.Settings.operator_defaults}>
+        <DialogBody>
+          <FormGroup label={t.components.editor2.Settings.defaults_when_adding}>
+            <div className="grid [grid-template-columns:repeat(2,minmax(0,auto))] gap-2 justify-start items-center">
+              {[6, 5, 4, 3, 2, 1, 0].map((rarity) => (
+                <Fragment key={rarity}>
+                  <span className="text-right">
+                    {rarity === 0 ? t.components.editor2.Settings.rarity({ count: rarity }) : '★'.repeat(rarity)}
+                  </span>
+                  <OperatorLevelEdit
+                    horizontal
+                    key={rarity}
+                    rarity={rarity}
+                    level={byRarity[rarity]?.level ?? getDefaultRequirements(rarity).level}
+                    elite={byRarity[rarity]?.elite ?? getDefaultRequirements(rarity).elite}
+                    onChange={({ level, elite }) => {
+                      setConfig({
+                        operatorDefaults: {
+                          byRarity: {
+                            ...byRarity,
+                            [rarity]: { level, elite },
+                          },
+                        },
+                      })
+                    }}
+                  />
+                </Fragment>
+              ))}
+            </div>
+          </FormGroup>
+          <Button
+            minimal
+            outlined
+            intent="danger"
+            text={t.components.editor2.Settings.reset_to_default}
+            onClick={() => {
+              setConfig({ operatorDefaults: undefined })
+            }}
+          />
+        </DialogBody>
+      </Dialog>
+    </>
+  )
+}

--- a/src/components/editor2/operator/GroupItem.tsx
+++ b/src/components/editor2/operator/GroupItem.tsx
@@ -322,7 +322,7 @@ const GroupTitle = memo(({ baseGroupAtom }: GroupItemProps) => {
         }
         const globalOperators = get(editorAtoms.operators)
         const favOperators = favGroup
-          .opers!.map(createOperator)
+          .opers!.map((o) => createOperator(o))
           // 过滤掉已经存在的全局干员
           .filter((favOperator) => !globalOperators.find((operator) => operator.id === favOperator.id))
         edit(() => {

--- a/src/components/editor2/operator/OperatorItem.tsx
+++ b/src/components/editor2/operator/OperatorItem.tsx
@@ -176,17 +176,18 @@ export const OperatorLevelEdit: FC<{
 
   return (
     <div className={clsx('flex items-center', horizontal ? 'gap-2' : 'flex-col-reverse')}>
-      {validLevel && (
-        <div
-          className={clsx(
-            !horizontal &&
-              '-mt-5 px-3 py-4 rounded-full bg-[radial-gradient(rgba(0,0,0,0.6)_10%,rgba(0,0,0,0.08)_35%,rgba(0,0,0,0)_50%)]',
-          )}
-        >
+      <div
+        className={clsx(
+          horizontal
+            ? 'w-8 h-6'
+            : 'mt-[-1.1rem] w-14 h-14 px-3 py-4 rounded-full bg-[radial-gradient(rgba(0,0,0,0.6)_10%,rgba(0,0,0,0.08)_35%,rgba(0,0,0,0)_50%)]',
+        )}
+      >
+        {validLevel && (
           <Button
             small
             minimal
-            className="!p-0 !border-0 pointer-events-auto hover:opacity-80"
+            className="size-full !p-0 !border-0 pointer-events-auto hover:opacity-80"
             title={t.components.editor2.OperatorItem.elite({
               level: validLevel.elite,
             })}
@@ -198,15 +199,15 @@ export const OperatorLevelEdit: FC<{
             }}
           >
             <img
-              className="w-8 h-7 object-contain"
+              className="size-full object-contain"
               src={getEliteIconUrl(validLevel.elite)}
               alt={t.components.editor2.OperatorItem.elite({
                 level: validLevel.elite,
               })}
             />
           </Button>
-        </div>
-      )}
+        )}
+      </div>
       <NumericInput2
         intOnly
         emitNaNString

--- a/src/components/editor2/operator/OperatorItem.tsx
+++ b/src/components/editor2/operator/OperatorItem.tsx
@@ -518,7 +518,7 @@ const OperatorModule: FC<{
           })}
           onClick={handleClick}
           onFocus={handleFocus}
-          selected={value === requirements?.module}
+          selected={value === normalizedModule}
         />
       )}
       onItemSelect={(value) => {

--- a/src/components/editor2/operator/OperatorItem.tsx
+++ b/src/components/editor2/operator/OperatorItem.tsx
@@ -7,9 +7,11 @@ import { FC, memo } from 'react'
 
 import { CopilotDocV1 } from 'models/copilot.schema'
 
+import { SetRequired } from 'type-fest'
 import { i18n, useTranslation } from '../../../i18n/i18n'
 import {
   OPERATORS,
+  OperatorInfo,
   adjustOperatorLevel,
   alternativeOperatorSkillUsages,
   getDefaultRequirements,
@@ -18,7 +20,6 @@ import {
   getSkillCount,
   getSkillUsageAltTitle,
   useLocalizedOperatorName,
-  withDefaultRequirements,
 } from '../../../models/operator'
 import { MasteryIcon } from '../../MasteryIcon'
 import { OperatorAvatar } from '../../OperatorAvatar'
@@ -47,13 +48,9 @@ const skillUsageClasses: Record<CopilotDocV1.SkillUsageType, string> = {
 export const OperatorItem: FC<OperatorItemProps> = memo(
   ({ operator, onChange, onRemove, onOverlay, isDragging, isSorting, attributes, listeners }) => {
     const t = useTranslation()
-    const edit = useEdit()
     const displayName = useLocalizedOperatorName(operator.name)
-    const [skillLevels, setSkillLevels] = useAtom(editorAtoms.skillLevelOverrides(operator.id))
     const setFavOperators = useSetAtom(editorFavOperatorsAtom)
     const info = OPERATORS.find(({ name }) => name === operator.name)
-    const skillCount = info ? getSkillCount(info) : 3
-    const requirements = withDefaultRequirements(operator.requirements, info?.rarity)
     const controlsEnabled = !onOverlay && !isDragging && !isSorting
 
     return (
@@ -109,382 +106,462 @@ export const OperatorItem: FC<OperatorItemProps> = memo(
             </Card>
           </PopoverNext>
 
-          {info?.prof !== 'TOKEN' && (
-            <>
-              <div className="absolute top-2 -left-5 ml-[2px] px-3 py-4 rounded-full bg-[radial-gradient(rgba(0,0,0,0.6)_10%,rgba(0,0,0,0.08)_35%,rgba(0,0,0,0)_50%)] pointer-events-none">
-                <Button
-                  small
-                  minimal
-                  className="!p-0 !border-0 pointer-events-auto hover:opacity-80"
-                  onClick={() => {
-                    edit(() => {
-                      onChange?.({
-                        ...operator,
-                        requirements: {
-                          ...operator.requirements,
-                          elite: (requirements.elite - 1 + 3) % 3,
-                        },
-                      })
-                      return {
-                        action: 'set-operator-level',
-                        desc: i18n.actions.editor2.set_operator_level,
-                        squashBy: operator.id,
-                      }
-                    })
-                  }}
-                >
-                  <img
-                    className="w-8 h-7 object-contain"
-                    src={getEliteIconUrl(requirements.elite)}
-                    alt={t.components.editor2.OperatorItem.elite({
-                      level: requirements.elite,
-                    })}
-                  />
-                </Button>
-              </div>
-              <div className="absolute -top-2 -left-2 flex flex-col items-center">
-                <NumericInput2
-                  intOnly
-                  min={1}
-                  buttonPosition="none"
-                  value={requirements.level}
-                  inputClassName="!w-9 h-9 !p-0 !leading-9 !rounded-full !border-2 !border-yellow-300 !bg-black/50 text-lg text-white font-semibold text-center !shadow-[0_1px_2px_rgba(0,0,0,0.9)]"
-                  onValueChange={(value) => {
-                    edit(() => {
-                      onChange?.({
-                        ...operator,
-                        requirements: {
-                          ...operator.requirements,
-                          level: value,
-                        },
-                      })
-                      return {
-                        action: 'set-operator-level',
-                        desc: i18n.actions.editor2.set_operator_level,
-                        squashBy: operator.id,
-                      }
-                    })
-                  }}
-                  onWheelFocused={(e) => {
-                    e.preventDefault()
-                    edit(() => {
-                      onChange?.({
-                        ...operator,
-                        requirements: {
-                          ...operator.requirements,
-                          ...adjustOperatorLevel({
-                            rarity: info?.rarity,
-                            level: requirements.level,
-                            elite: requirements.elite,
-                            delta: e.deltaY > 0 ? -10 : 10,
-                          }),
-                        },
-                      })
-                      return {
-                        action: 'set-operator-level',
-                        desc: i18n.actions.editor2.set_operator_level,
-                        squashBy: operator.id,
-                      }
-                    })
-                  }}
-                />
-              </div>
-            </>
-          )}
+          {info?.prof !== 'TOKEN' && <OperatorLevel operator={operator} onChange={onChange} />}
           <div className="flex h-6">
-            {controlsEnabled && (
-              <DetailedSelect
-                items={[
-                  {
-                    type: 'header' as const,
-                    header: t.components.editor2.label.opers.skill_usage,
-                  },
-                  ...alternativeOperatorSkillUsages,
-                ].map((item) =>
-                  item.type === 'choice' && item.value === CopilotDocV1.SkillUsageType.ReadyToUseTimes
-                    ? {
-                        ...item,
-                        menuItemProps: { shouldDismissPopover: false },
-                        description: (
-                          <>
-                            <div>{typeof item.description === 'function' ? item.description() : item.description}</div>
-                            <span className="mr-2 text-lg">x</span>
-                            <NumericInput2
-                              intOnly
-                              min={1}
-                              className="inline-flex"
-                              inputClassName="!p-0 !w-8 text-center font-semibold"
-                              value={operator.skillTimes ?? 1}
-                              wheelStepSize={1}
-                              onValueChange={(v) => {
-                                edit(() => {
-                                  onChange?.({
-                                    ...operator,
-                                    skillTimes: v,
-                                  })
-                                  return {
-                                    action: 'set-operator-skillTimes',
-                                    desc: i18n.actions.editor2.set_operator_skill_count,
-                                    squashBy: operator.id,
-                                  }
-                                })
-                              }}
-                            />
-                          </>
-                        ),
-                      }
-                    : item,
-                )}
-                value={operator.skillUsage ?? CopilotDocV1.SkillUsageType.None}
-                onItemSelect={(item) => {
-                  if (item.value === operator.skillUsage) return
-                  edit(() => {
-                    onChange?.({
-                      ...operator,
-                      skillUsage: item.value as number,
-                    })
-                    return {
-                      action: 'set-operator-skillUsage',
-                      desc: i18n.actions.editor2.set_operator_skill_usage,
-                    }
-                  })
-                }}
-              >
-                <Button
-                  small
-                  minimal
-                  className={clsx(
-                    '!px-0 h-full !border-none !text-[.7rem] !leading-3 !font-normal !underline underline-offset-2',
-                    skillUsageClasses[operator.skillUsage ?? CopilotDocV1.SkillUsageType.None],
-                  )}
-                >
-                  {getSkillUsageAltTitle(
-                    operator.skillUsage ?? CopilotDocV1.SkillUsageType.None,
-                    operator.skillTimes ?? 1,
-                  )}
-                </Button>
-              </DetailedSelect>
-            )}
+            {controlsEnabled && <OperatorSkillUsage operator={operator} onChange={onChange} />}
           </div>
         </div>
 
         <ul className="w-8 grid grid-rows-4 gap-1 ml-1 mt-1">
-          {controlsEnabled &&
-            Array.from({ length: skillCount }, (_, index) => {
-              const available = index <= requirements.elite
-              const skillNumber = index + 1
-              const selected = operator.skill === skillNumber
-              const maxSkillLevel = requirements.elite === 2 ? 10 : 7
-              const skillLevel = selected
-                ? requirements.skillLevel
-                : (skillLevels[skillNumber] ?? getDefaultRequirements(info?.rarity).skillLevel)
-
-              const selectSkill = () => {
-                if (operator.skill !== skillNumber) {
-                  edit(() => {
-                    onChange?.({
-                      ...operator,
-                      skill: skillNumber,
-                      requirements: {
-                        ...operator.requirements,
-                        // override with the current skill level
-                        skillLevel,
-                      },
-                    })
-                    return {
-                      action: 'set-operator-skill',
-                      desc: i18n.actions.editor2.set_operator_skill,
-                    }
-                  })
-                }
-              }
-
-              return (
-                <li
-                  key={index}
-                  className={clsx(
-                    'relative',
-                    selected
-                      ? available
-                        ? '!bg-purple-100 dark:!bg-purple-900 dark:text-purple-200 text-purple-800'
-                        : '!bg-red-100 dark:!bg-red-900 dark:text-red-200 text-red-800'
-                      : '!bg-gray-300 dark:!bg-gray-600 opacity-15 dark:opacity-25 hover:opacity-30 dark:hover:opacity-50',
-                  )}
-                >
-                  <NumericInput2
-                    intOnly
-                    title={
-                      available
-                        ? t.models.operator.skill_number({ count: skillNumber })
-                        : t.components.editor2.OperatorItem.skill_not_available
-                    }
-                    min={0}
-                    buttonPosition="none"
-                    value={skillLevel <= 7 ? skillLevel : ''} // 大于 7 级时置空然后用 padding 占位，以留出空间在上面放置专精图标
-                    inputClassName={clsx(
-                      '!w-8 h-8 !p-0 !leading-8 !bg-transparent text-center font-bold text-xl !text-inherit !rounded-none !border-2 !border-current [&:not(:focus)]:cursor-pointer',
-                      skillLevel > 7 && '!pl-4',
-                    )}
-                    onClick={selectSkill}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
-                        selectSkill()
-                      }
-                    }}
-                    onValueChange={(_, valueStr) => {
-                      edit(() => {
-                        // 拿到新输入的一位数字（比如原来是 5，输入 2，变成 52，这里会拿到 2）
-                        let newLevel =
-                          valueStr.length > 1 ? +String(valueStr).replace(String(skillLevel), '') : Number(valueStr)
-
-                        if (newLevel === 0) {
-                          newLevel = 10
-                        }
-                        newLevel = clamp(newLevel, 1, maxSkillLevel)
-
-                        setSkillLevels((prev) => ({
-                          ...prev,
-                          [skillNumber]: newLevel,
-                        }))
-                        onChange?.({
-                          ...operator,
-                          requirements: {
-                            ...operator.requirements,
-                            skillLevel: newLevel,
-                          },
-                        })
-                        return {
-                          action: 'set-operator-skillLevel',
-                          desc: i18n.actions.editor2.set_operator_skill_level,
-                          squashBy: operator.id,
-                        }
-                      })
-                    }}
-                    onWheelFocused={(e) => {
-                      e.preventDefault()
-                      edit(() => {
-                        const newLevel = clamp(requirements.skillLevel + (e.deltaY > 0 ? -1 : 1), 1, maxSkillLevel)
-                        setSkillLevels((prev) => ({
-                          ...prev,
-                          [skillNumber]: newLevel,
-                        }))
-                        onChange?.({
-                          ...operator,
-                          requirements: {
-                            ...operator.requirements,
-                            skillLevel: newLevel,
-                          },
-                        })
-                        return {
-                          action: 'set-operator-skillLevel',
-                          desc: i18n.actions.editor2.set_operator_skill_level,
-                          squashBy: operator.id,
-                        }
-                      })
-                    }}
-                  />
-                  {skillLevel > 7 && (
-                    <MasteryIcon
-                      className="absolute top-0 left-0 w-full h-full p-2 pointer-events-none"
-                      mastery={skillLevel - 7}
-                    />
-                  )}
-                  {!available && (
-                    <div className="absolute top-1/2 left-0 right-0 h-0.5 bg-current rotate-45 -translate-y-px pointer-events-none" />
-                  )}
-                </li>
-              )
-            })}
-          {controlsEnabled && info?.modules && (
-            <Select
-              className="row-start-4"
-              filterable={false}
-              items={[
-                CopilotDocV1.Module.Default,
-                ...info.modules
-                  .map((m) =>
-                    m ? (CopilotDocV1.Module[m] as CopilotDocV1.Module | undefined) : CopilotDocV1.Module.Original,
-                  )
-                  .filter((m) => m !== undefined),
-              ]}
-              itemRenderer={(value, { handleClick, handleFocus, modifiers }) => (
-                <MenuItem
-                  roleStructure="listoption"
-                  key={value}
-                  className={clsx(
-                    'min-w-12 !rounded-none text-base font-serif font-bold text-center text-slate-600 dark:text-slate-300',
-                    modifiers.active && Classes.ACTIVE,
-                  )}
-                  text={
-                    value === CopilotDocV1.Module.Default ? (
-                      <Icon icon="disable" />
-                    ) : value === CopilotDocV1.Module.Original ? (
-                      <Icon icon="small-square" />
-                    ) : (
-                      getModuleName(value)
-                    )
-                  }
-                  title={t.components.editor2.OperatorItem.module_title({
-                    count: value,
-                    name: getModuleName(value),
-                  })}
-                  onClick={handleClick}
-                  onFocus={handleFocus}
-                  selected={value === requirements.module}
-                />
-              )}
-              onItemSelect={(value) => {
-                edit(() => {
-                  onChange?.({
-                    ...operator,
-                    requirements: {
-                      ...operator.requirements,
-                      module: value,
-                    },
-                  })
-                  return {
-                    action: 'set-operator-module',
-                    desc: i18n.actions.editor2.set_operator_module,
-                    squashBy: operator.id,
-                  }
-                })
-              }}
-              popoverProps={{
-                placement: 'top',
-                popoverClassName: '!rounded-none [&_.bp6-popover-content]:!p-0 [&_.bp6-menu]:min-w-0 [&_li]:!mb-0',
-              }}
-            >
-              <Button
-                small
-                minimal
-                title={
-                  t.components.editor2.OperatorItem.module +
-                  ': ' +
-                  t.components.editor2.OperatorItem.module_title({
-                    count: requirements.module,
-                    name: getModuleName(requirements.module),
-                  })
-                }
-                className={clsx(
-                  'w-4 h-4 !p-0 flex items-center justify-center font-serif !font-bold !text-base !rounded-none !border-2 !border-current',
-                  requirements.module !== CopilotDocV1.Module.Default
-                    ? '!bg-purple-100 dark:!bg-purple-900 dark:!text-purple-200 !text-purple-800'
-                    : '!bg-gray-300 dark:!bg-gray-600 opacity-15 dark:opacity-25 hover:opacity-30 dark:hover:opacity-50',
-                )}
-              >
-                {requirements.module === CopilotDocV1.Module.Default ? null : requirements.module ===
-                  CopilotDocV1.Module.Original ? (
-                  <Icon icon="small-square" />
-                ) : (
-                  getModuleName(requirements.module)
-                )}
-              </Button>
-            </Select>
-          )}
+          {controlsEnabled && <OperatorSkill operator={operator} onChange={onChange} />}
+          {controlsEnabled && info?.modules && <OperatorModule operator={operator} info={info} onChange={onChange} />}
         </ul>
       </div>
     )
   },
 )
 OperatorItem.displayName = 'OperatorItem'
+
+const DEFAULT_ELITE = 0
+const DEFAULT_LEVEL = 1
+const LEVEL_PLACEHOLDER = '?'
+
+const OperatorLevel: FC<{
+  operator: EditorOperator
+  onChange?: (operator: EditorOperator) => void
+}> = memo(({ operator, onChange }) => {
+  const t = useTranslation()
+  const edit = useEdit()
+  const info = OPERATORS.find(({ name }) => name === operator.name)
+  const requirements = operator.requirements
+  // 只有当 elite 和 level 都存在时才是合法的等级
+  const validLevel =
+    requirements?.elite !== undefined && requirements?.level !== undefined
+      ? { level: requirements.level, elite: requirements.elite }
+      : undefined
+
+  return (
+    <>
+      {validLevel && (
+        <div className="absolute top-2 -left-5 ml-[2px] px-3 py-4 rounded-full bg-[radial-gradient(rgba(0,0,0,0.6)_10%,rgba(0,0,0,0.08)_35%,rgba(0,0,0,0)_50%)] pointer-events-none">
+          <Button
+            small
+            minimal
+            className="!p-0 !border-0 pointer-events-auto hover:opacity-80"
+            title={t.components.editor2.OperatorItem.elite({
+              level: validLevel.elite,
+            })}
+            onClick={() => {
+              edit(() => {
+                onChange?.({
+                  ...operator,
+                  requirements: {
+                    ...requirements,
+                    elite: (validLevel.elite - 1 + 3) % 3,
+                  },
+                })
+                return {
+                  action: 'set-operator-level',
+                  desc: i18n.actions.editor2.set_operator_level,
+                  squashBy: operator.id,
+                }
+              })
+            }}
+          >
+            <img
+              className="w-8 h-7 object-contain"
+              src={getEliteIconUrl(validLevel.elite)}
+              alt={t.components.editor2.OperatorItem.elite({
+                level: validLevel.elite,
+              })}
+            />
+          </Button>
+        </div>
+      )}
+      <div className="absolute -top-2 -left-2 flex flex-col items-center">
+        <NumericInput2
+          intOnly
+          emitNaNString
+          allowNumericCharactersOnly={false}
+          buttonPosition="none"
+          title={validLevel ? t.components.editor2.OperatorItem.level : t.components.editor2.OperatorItem.level_unset}
+          value={validLevel ? validLevel.level : LEVEL_PLACEHOLDER}
+          inputClassName="!w-9 h-9 !p-0 !leading-9 !rounded-full !border-2 !border-yellow-300 !bg-black/50 text-lg text-white font-semibold text-center !shadow-[0_1px_2px_rgba(0,0,0,0.9)]"
+          onValueChange={(value, valueStr) => {
+            if (Number.isNaN(value)) {
+              // 我们在等级缺失的时候使用 ? 作为占位符，所以这里尝试把 ? 替换掉以处理用户在这种情况下的输入
+              value = parseInt(valueStr.replaceAll(LEVEL_PLACEHOLDER, ''))
+              if (Number.isNaN(value)) {
+                return
+              }
+            }
+            edit(() => {
+              onChange?.({
+                ...operator,
+                requirements: {
+                  ...requirements,
+                  level: value,
+                  elite: validLevel ? validLevel.elite : DEFAULT_ELITE,
+                },
+              })
+              return {
+                action: 'set-operator-level',
+                desc: i18n.actions.editor2.set_operator_level,
+                squashBy: operator.id,
+              }
+            })
+          }}
+          onWheelFocused={(e) => {
+            e.preventDefault()
+            edit(() => {
+              onChange?.({
+                ...operator,
+                requirements: {
+                  ...requirements,
+                  ...adjustOperatorLevel({
+                    rarity: info?.rarity,
+                    level: validLevel ? validLevel.level : DEFAULT_LEVEL,
+                    elite: validLevel ? validLevel.elite : DEFAULT_ELITE,
+                    delta: e.deltaY > 0 ? -10 : 10,
+                  }),
+                },
+              })
+              return {
+                action: 'set-operator-level',
+                desc: i18n.actions.editor2.set_operator_level,
+                squashBy: operator.id,
+              }
+            })
+          }}
+        />
+      </div>
+    </>
+  )
+})
+OperatorLevel.displayName = 'OperatorLevel'
+
+const OperatorSkillUsage: FC<{
+  operator: EditorOperator
+  onChange?: (operator: EditorOperator) => void
+}> = memo(({ operator, onChange }) => {
+  const t = useTranslation()
+  const edit = useEdit()
+  const normalizedSkillUsage = operator.skillUsage ?? CopilotDocV1.SkillUsageType.None
+
+  return (
+    <DetailedSelect
+      items={[
+        {
+          type: 'header' as const,
+          header: t.components.editor2.label.opers.skill_usage,
+        },
+        ...alternativeOperatorSkillUsages,
+      ].map((item) =>
+        item.type === 'choice' && item.value === CopilotDocV1.SkillUsageType.ReadyToUseTimes
+          ? {
+              ...item,
+              menuItemProps: { shouldDismissPopover: false },
+              description: (
+                <>
+                  <div>{typeof item.description === 'function' ? item.description() : item.description}</div>
+                  <span className="mr-2 text-lg">x</span>
+                  <NumericInput2
+                    intOnly
+                    min={1}
+                    className="inline-flex"
+                    inputClassName="!p-0 !w-8 text-center font-semibold"
+                    value={operator.skillTimes ?? 1}
+                    wheelStepSize={1}
+                    onValueChange={(v) => {
+                      edit(() => {
+                        onChange?.({
+                          ...operator,
+                          skillTimes: v,
+                        })
+                        return {
+                          action: 'set-operator-skillTimes',
+                          desc: i18n.actions.editor2.set_operator_skill_count,
+                          squashBy: operator.id,
+                        }
+                      })
+                    }}
+                  />
+                </>
+              ),
+            }
+          : item,
+      )}
+      value={normalizedSkillUsage}
+      onItemSelect={(item) => {
+        if (item.value === normalizedSkillUsage) return
+        edit(() => {
+          onChange?.({
+            ...operator,
+            skillUsage: item.value as number,
+          })
+          return {
+            action: 'set-operator-skillUsage',
+            desc: i18n.actions.editor2.set_operator_skill_usage,
+          }
+        })
+      }}
+    >
+      <Button
+        small
+        minimal
+        className={clsx(
+          '!px-0 h-full !border-none !text-[.7rem] !leading-3 !font-normal !underline underline-offset-2',
+          skillUsageClasses[normalizedSkillUsage],
+        )}
+      >
+        {getSkillUsageAltTitle(normalizedSkillUsage, operator.skillTimes ?? 1)}
+      </Button>
+    </DetailedSelect>
+  )
+})
+
+const OperatorSkill: FC<{
+  operator: EditorOperator
+  onChange?: (operator: EditorOperator) => void
+}> = memo(({ operator, onChange }) => {
+  const t = useTranslation()
+  const edit = useEdit()
+  // 覆盖值：当用户选中了某个技能并设置了等级，这个等级会暂存在这里，以便在切换到其他技能再切换回来时还原出来
+  const [skillLevels, setSkillLevels] = useAtom(editorAtoms.skillLevelOverrides(operator.id))
+  const info = OPERATORS.find(({ name }) => name === operator.name)
+  const requirements = operator.requirements
+  // 如果没有设置精英化等级，则默认当作精2，也就是允许使用任何技能
+  const normalizedElite = requirements?.elite ?? 2
+  const skillCount = info ? getSkillCount(info) : 3
+
+  return Array.from({ length: skillCount }, (_, index) => {
+    // 该技能是否在当前精英化等级可用：精0=技能1，精1=技能1/2，精2=技能1/2/3
+    const available = index <= normalizedElite
+    const skillNumber = index + 1
+    const selected = operator.skill === skillNumber
+    const maxSkillLevel = normalizedElite === 2 ? 10 : 7
+    const skillLevel = selected
+      ? // 如果选中了当前技能，但 requirements.skillLevel 是空的（一般不会发生，除非手动改了 JSON），就填个 1 级
+        (requirements?.skillLevel ?? 1)
+      : // 如果没选中，就填入覆盖值或者默认值
+        (skillLevels[skillNumber] ?? getDefaultRequirements(info?.rarity).skillLevel)
+
+    const selectSkill = () => {
+      if (operator.skill !== skillNumber) {
+        edit(() => {
+          onChange?.({
+            ...operator,
+            skill: skillNumber,
+            requirements: {
+              ...requirements,
+              // override with the current skill level
+              skillLevel,
+            },
+          })
+          return {
+            action: 'set-operator-skill',
+            desc: i18n.actions.editor2.set_operator_skill,
+          }
+        })
+      }
+    }
+
+    return (
+      <li
+        key={index}
+        className={clsx(
+          'relative',
+          selected
+            ? available
+              ? '!bg-purple-100 dark:!bg-purple-900 dark:text-purple-200 text-purple-800'
+              : '!bg-red-100 dark:!bg-red-900 dark:text-red-200 text-red-800'
+            : '!bg-gray-300 dark:!bg-gray-600 opacity-15 dark:opacity-25 hover:opacity-30 dark:hover:opacity-50',
+        )}
+      >
+        <NumericInput2
+          intOnly
+          title={
+            available
+              ? selected
+                ? t.components.editor2.OperatorItem.selected_skill({
+                    skill: t.models.operator.skill_number({ count: skillNumber }),
+                  })
+                : t.models.operator.skill_number({ count: skillNumber })
+              : t.components.editor2.OperatorItem.skill_not_available
+          }
+          min={0}
+          buttonPosition="none"
+          value={skillLevel <= 7 ? skillLevel : ''} // 大于 7 级时置空然后用 padding 占位，以留出空间在上面放置专精图标
+          inputClassName={clsx(
+            '!w-8 h-8 !p-0 !leading-8 !bg-transparent text-center font-bold text-xl !text-inherit !rounded-none !border-2 !border-current [&:not(:focus)]:cursor-pointer',
+            skillLevel > 7 && '!pl-4',
+          )}
+          onClick={selectSkill}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault()
+              selectSkill()
+            }
+          }}
+          onValueChange={(_, valueStr) => {
+            edit(() => {
+              // 拿到新输入的一位数字（比如原来是 5，输入 2，变成 52，这里会拿到 2）
+              let newLevel = valueStr.length > 1 ? +String(valueStr).replace(String(skillLevel), '') : Number(valueStr)
+
+              if (newLevel === 0) {
+                newLevel = 10
+              }
+              newLevel = clamp(newLevel, 1, maxSkillLevel)
+
+              setSkillLevels((prev) => ({
+                ...prev,
+                [skillNumber]: newLevel,
+              }))
+              onChange?.({
+                ...operator,
+                requirements: {
+                  ...requirements,
+                  skillLevel: newLevel,
+                },
+              })
+              return {
+                action: 'set-operator-skillLevel',
+                desc: i18n.actions.editor2.set_operator_skill_level,
+                squashBy: operator.id,
+              }
+            })
+          }}
+          onWheelFocused={(e) => {
+            e.preventDefault()
+            edit(() => {
+              const newLevel = clamp(skillLevel + (e.deltaY > 0 ? -1 : 1), 1, maxSkillLevel)
+              setSkillLevels((prev) => ({
+                ...prev,
+                [skillNumber]: newLevel,
+              }))
+              onChange?.({
+                ...operator,
+                requirements: {
+                  ...requirements,
+                  skillLevel: newLevel,
+                },
+              })
+              return {
+                action: 'set-operator-skillLevel',
+                desc: i18n.actions.editor2.set_operator_skill_level,
+                squashBy: operator.id,
+              }
+            })
+          }}
+        />
+        {skillLevel > 7 && (
+          <MasteryIcon
+            className="absolute top-0 left-0 w-full h-full p-2 pointer-events-none"
+            mastery={skillLevel - 7}
+          />
+        )}
+        {!available && (
+          <div className="absolute top-1/2 left-0 right-0 h-0.5 bg-current rotate-45 -translate-y-px pointer-events-none" />
+        )}
+      </li>
+    )
+  })
+})
+OperatorSkill.displayName = 'OperatorSkills'
+
+const OperatorModule: FC<{
+  operator: EditorOperator
+  info: SetRequired<OperatorInfo, 'modules'>
+  onChange?: (operator: EditorOperator) => void
+}> = memo(({ operator, info, onChange }) => {
+  const t = useTranslation()
+  const edit = useEdit()
+  const requirements = operator.requirements
+  const normalizedModule = requirements?.module ?? CopilotDocV1.Module.Default
+
+  return (
+    <Select
+      className="row-start-4"
+      filterable={false}
+      items={[
+        CopilotDocV1.Module.Default,
+        ...info.modules
+          .map((m) => (m ? (CopilotDocV1.Module[m] as CopilotDocV1.Module | undefined) : CopilotDocV1.Module.Original))
+          .filter((m) => m !== undefined),
+      ]}
+      itemRenderer={(value, { handleClick, handleFocus, modifiers }) => (
+        <MenuItem
+          roleStructure="listoption"
+          key={value}
+          className={clsx(
+            'min-w-12 !rounded-none text-base font-serif font-bold text-center text-slate-600 dark:text-slate-300',
+            modifiers.active && Classes.ACTIVE,
+          )}
+          text={
+            value === CopilotDocV1.Module.Default ? (
+              <Icon icon="disable" />
+            ) : value === CopilotDocV1.Module.Original ? (
+              <Icon icon="small-square" />
+            ) : (
+              getModuleName(value)
+            )
+          }
+          title={t.components.editor2.OperatorItem.module_title({
+            count: value,
+            name: getModuleName(value),
+          })}
+          onClick={handleClick}
+          onFocus={handleFocus}
+          selected={value === requirements?.module}
+        />
+      )}
+      onItemSelect={(value) => {
+        if (value === normalizedModule) return
+        edit(() => {
+          onChange?.({
+            ...operator,
+            requirements: {
+              ...requirements,
+              module: value,
+            },
+          })
+          return {
+            action: 'set-operator-module',
+            desc: i18n.actions.editor2.set_operator_module,
+            squashBy: operator.id,
+          }
+        })
+      }}
+      popoverProps={{
+        placement: 'top',
+        popoverClassName: '!rounded-none [&_.bp6-popover-content]:!p-0 [&_.bp6-menu]:min-w-0 [&_li]:!mb-0',
+      }}
+    >
+      <Button
+        small
+        minimal
+        title={
+          t.components.editor2.OperatorItem.module +
+          ': ' +
+          t.components.editor2.OperatorItem.module_title({
+            count: normalizedModule,
+            name: getModuleName(normalizedModule),
+          })
+        }
+        className={clsx(
+          'w-4 h-4 !p-0 flex items-center justify-center font-serif !font-bold !text-base !rounded-none !border-2 !border-current',
+          normalizedModule !== CopilotDocV1.Module.Default
+            ? '!bg-purple-100 dark:!bg-purple-900 dark:!text-purple-200 !text-purple-800'
+            : '!bg-gray-300 dark:!bg-gray-600 opacity-15 dark:opacity-25 hover:opacity-30 dark:hover:opacity-50',
+        )}
+      >
+        {normalizedModule === CopilotDocV1.Module.Default ? null : normalizedModule === CopilotDocV1.Module.Original ? (
+          <Icon icon="small-square" />
+        ) : (
+          getModuleName(normalizedModule)
+        )}
+      </Button>
+    </Select>
+  )
+})
+OperatorModule.displayName = 'OperatorModule'

--- a/src/components/editor2/operator/OperatorItem.tsx
+++ b/src/components/editor2/operator/OperatorItem.tsx
@@ -179,7 +179,7 @@ export const OperatorLevelEdit: FC<{
       {validLevel && (
         <div
           className={clsx(
-            horizontal ||
+            !horizontal &&
               '-mt-5 px-3 py-4 rounded-full bg-[radial-gradient(rgba(0,0,0,0.6)_10%,rgba(0,0,0,0.08)_35%,rgba(0,0,0,0)_50%)]',
           )}
         >

--- a/src/components/editor2/operator/OperatorItem.tsx
+++ b/src/components/editor2/operator/OperatorItem.tsx
@@ -10,10 +10,10 @@ import { CopilotDocV1 } from 'models/copilot.schema'
 import { SetRequired } from 'type-fest'
 import { i18n, useTranslation } from '../../../i18n/i18n'
 import {
-  OPERATORS,
   OperatorInfo,
   adjustOperatorLevel,
   alternativeOperatorSkillUsages,
+  findOperatorByName,
   getDefaultRequirements,
   getEliteIconUrl,
   getModuleName,
@@ -50,7 +50,7 @@ export const OperatorItem: FC<OperatorItemProps> = memo(
     const t = useTranslation()
     const displayName = useLocalizedOperatorName(operator.name)
     const setFavOperators = useSetAtom(editorFavOperatorsAtom)
-    const info = OPERATORS.find(({ name }) => name === operator.name)
+    const info = findOperatorByName(operator.name)
     const controlsEnabled = !onOverlay && !isDragging && !isSorting
 
     return (
@@ -122,28 +122,67 @@ export const OperatorItem: FC<OperatorItemProps> = memo(
 )
 OperatorItem.displayName = 'OperatorItem'
 
-const DEFAULT_ELITE = 0
-const DEFAULT_LEVEL = 1
-const LEVEL_PLACEHOLDER = '?'
-
 const OperatorLevel: FC<{
   operator: EditorOperator
   onChange?: (operator: EditorOperator) => void
 }> = memo(({ operator, onChange }) => {
-  const t = useTranslation()
   const edit = useEdit()
-  const info = OPERATORS.find(({ name }) => name === operator.name)
+  const info = findOperatorByName(operator.name)
   const requirements = operator.requirements
-  // 只有当 elite 和 level 都存在时才是合法的等级
-  const validLevel =
-    requirements?.elite !== undefined && requirements?.level !== undefined
-      ? { level: requirements.level, elite: requirements.elite }
-      : undefined
 
   return (
-    <>
+    <div className="absolute -top-2 [left:-1.15rem] pointer-events-none">
+      <OperatorLevelEdit
+        rarity={info?.rarity}
+        level={requirements?.level}
+        elite={requirements?.elite}
+        onChange={({ level, elite }) => {
+          edit(() => {
+            onChange?.({
+              ...operator,
+              requirements: {
+                ...requirements,
+                level,
+                elite,
+              },
+            })
+            return {
+              action: 'set-operator-level',
+              desc: i18n.actions.editor2.set_operator_level,
+              squashBy: operator.id,
+            }
+          })
+        }}
+      />
+    </div>
+  )
+})
+OperatorLevel.displayName = 'OperatorLevel'
+
+const DEFAULT_ELITE = 0
+const DEFAULT_LEVEL = 1
+const LEVEL_PLACEHOLDER = '?'
+
+export const OperatorLevelEdit: FC<{
+  horizontal?: boolean
+  rarity?: number
+  level?: number
+  elite?: number
+  onChange?: (data: { level: number; elite: number }) => void
+}> = memo(({ horizontal, rarity, level, elite, onChange }) => {
+  const t = useTranslation()
+  // 只有当 elite 和 level 都存在时才是合法的等级
+  const validLevel = elite !== undefined && level !== undefined ? { level, elite } : undefined
+
+  return (
+    <div className={clsx('flex items-center', horizontal ? 'gap-2' : 'flex-col-reverse')}>
       {validLevel && (
-        <div className="absolute top-2 -left-5 ml-[2px] px-3 py-4 rounded-full bg-[radial-gradient(rgba(0,0,0,0.6)_10%,rgba(0,0,0,0.08)_35%,rgba(0,0,0,0)_50%)] pointer-events-none">
+        <div
+          className={clsx(
+            horizontal ||
+              '-mt-5 px-3 py-4 rounded-full bg-[radial-gradient(rgba(0,0,0,0.6)_10%,rgba(0,0,0,0.08)_35%,rgba(0,0,0,0)_50%)]',
+          )}
+        >
           <Button
             small
             minimal
@@ -152,19 +191,9 @@ const OperatorLevel: FC<{
               level: validLevel.elite,
             })}
             onClick={() => {
-              edit(() => {
-                onChange?.({
-                  ...operator,
-                  requirements: {
-                    ...requirements,
-                    elite: (validLevel.elite - 1 + 3) % 3,
-                  },
-                })
-                return {
-                  action: 'set-operator-level',
-                  desc: i18n.actions.editor2.set_operator_level,
-                  squashBy: operator.id,
-                }
+              onChange?.({
+                level: validLevel.level,
+                elite: (validLevel.elite - 1 + 3) % 3,
               })
             }}
           >
@@ -178,67 +207,43 @@ const OperatorLevel: FC<{
           </Button>
         </div>
       )}
-      <div className="absolute -top-2 -left-2 flex flex-col items-center">
-        <NumericInput2
-          intOnly
-          emitNaNString
-          allowNumericCharactersOnly={false}
-          buttonPosition="none"
-          title={validLevel ? t.components.editor2.OperatorItem.level : t.components.editor2.OperatorItem.level_unset}
-          value={validLevel ? validLevel.level : LEVEL_PLACEHOLDER}
-          inputClassName="!w-9 h-9 !p-0 !leading-9 !rounded-full !border-2 !border-yellow-300 !bg-black/50 text-lg text-white font-semibold text-center !shadow-[0_1px_2px_rgba(0,0,0,0.9)]"
-          onValueChange={(value, valueStr) => {
+      <NumericInput2
+        intOnly
+        emitNaNString
+        allowNumericCharactersOnly={false}
+        buttonPosition="none"
+        className="pointer-events-auto"
+        title={validLevel ? t.components.editor2.OperatorItem.level : t.components.editor2.OperatorItem.level_unset}
+        value={validLevel ? validLevel.level : LEVEL_PLACEHOLDER}
+        inputClassName="!w-9 h-9 !p-0 !leading-9 !rounded-full !border-2 !border-yellow-300 !bg-black/50 text-lg text-white font-semibold text-center !shadow-[0_1px_2px_rgba(0,0,0,0.9)]"
+        onValueChange={(value, valueStr) => {
+          if (Number.isNaN(value)) {
+            // 我们在等级缺失的时候使用 ? 作为占位符，所以这里尝试把 ? 替换掉以处理用户在这种情况下的输入
+            value = parseInt(valueStr.replaceAll(LEVEL_PLACEHOLDER, ''))
             if (Number.isNaN(value)) {
-              // 我们在等级缺失的时候使用 ? 作为占位符，所以这里尝试把 ? 替换掉以处理用户在这种情况下的输入
-              value = parseInt(valueStr.replaceAll(LEVEL_PLACEHOLDER, ''))
-              if (Number.isNaN(value)) {
-                return
-              }
+              return
             }
-            edit(() => {
-              onChange?.({
-                ...operator,
-                requirements: {
-                  ...requirements,
-                  level: value,
-                  elite: validLevel ? validLevel.elite : DEFAULT_ELITE,
-                },
-              })
-              return {
-                action: 'set-operator-level',
-                desc: i18n.actions.editor2.set_operator_level,
-                squashBy: operator.id,
-              }
-            })
-          }}
-          onWheelFocused={(e) => {
-            e.preventDefault()
-            edit(() => {
-              onChange?.({
-                ...operator,
-                requirements: {
-                  ...requirements,
-                  ...adjustOperatorLevel({
-                    rarity: info?.rarity,
-                    level: validLevel ? validLevel.level : DEFAULT_LEVEL,
-                    elite: validLevel ? validLevel.elite : DEFAULT_ELITE,
-                    delta: e.deltaY > 0 ? -10 : 10,
-                  }),
-                },
-              })
-              return {
-                action: 'set-operator-level',
-                desc: i18n.actions.editor2.set_operator_level,
-                squashBy: operator.id,
-              }
-            })
-          }}
-        />
-      </div>
-    </>
+          }
+          onChange?.({
+            level: value,
+            elite: validLevel ? validLevel.elite : DEFAULT_ELITE,
+          })
+        }}
+        onWheelFocused={(e) => {
+          e.preventDefault()
+          onChange?.({
+            ...adjustOperatorLevel({
+              rarity,
+              level: validLevel ? validLevel.level : DEFAULT_LEVEL,
+              elite: validLevel ? validLevel.elite : DEFAULT_ELITE,
+              delta: e.deltaY > 0 ? -10 : 10,
+            }),
+          })
+        }}
+      />
+    </div>
   )
 })
-OperatorLevel.displayName = 'OperatorLevel'
 
 const OperatorSkillUsage: FC<{
   operator: EditorOperator
@@ -328,7 +333,7 @@ const OperatorSkill: FC<{
   const edit = useEdit()
   // 覆盖值：当用户选中了某个技能并设置了等级，这个等级会暂存在这里，以便在切换到其他技能再切换回来时还原出来
   const [skillLevels, setSkillLevels] = useAtom(editorAtoms.skillLevelOverrides(operator.id))
-  const info = OPERATORS.find(({ name }) => name === operator.name)
+  const info = findOperatorByName(operator.name)
   const requirements = operator.requirements
   // 如果没有设置精英化等级，则默认当作精2，也就是允许使用任何技能
   const normalizedElite = requirements?.elite ?? 2

--- a/src/components/editor2/reconciliation.ts
+++ b/src/components/editor2/reconciliation.ts
@@ -9,7 +9,7 @@ import { findOperatorByName, getDefaultRequirements } from '../../models/operato
 import { FavGroup, favGroupAtom } from '../../store/useFavGroups'
 import { FavOperator, favOperatorAtom } from '../../store/useFavOperators'
 import { snakeCaseKeysUnicode } from '../../utils/object'
-import { EditorAction, EditorGroup, EditorOperation, EditorOperator } from './editor-state'
+import { EditorAction, EditorGroup, EditorOperation, EditorOperator, getEditorConfig } from './editor-state'
 import { CopilotOperationLoose } from './validation/schema'
 
 export type WithPartialCoordinates<T> = T extends {
@@ -58,7 +58,18 @@ export function createOperator(
 ): EditorOperator {
   const info = findOperatorByName(initialValues.name)
   const shouldApplyDefaultRequirements = applyDefaultRequirements && (!info || info.prof !== 'TOKEN')
-  const defaultRequirements = shouldApplyDefaultRequirements ? getDefaultRequirements(info?.rarity) : undefined
+  let defaultRequirements: CopilotDocV1.Requirements | undefined
+  if (shouldApplyDefaultRequirements) {
+    const rarity = info?.rarity ?? 6
+    const customDefaults = getEditorConfig().operatorDefaults?.byRarity?.[rarity]
+    if (customDefaults) {
+      defaultRequirements = {
+        level: customDefaults.level,
+        elite: customDefaults.elite,
+      }
+    }
+    defaultRequirements = defaults({}, defaultRequirements, getDefaultRequirements(rarity))
+  }
   const operator: EditorOperator = defaultsDeep(
     { id: uniqueId() } satisfies Omit<EditorOperator, 'name'>,
     initialValues,

--- a/src/components/editor2/reconciliation.ts
+++ b/src/components/editor2/reconciliation.ts
@@ -1,10 +1,11 @@
 import camelcaseKeys from 'camelcase-keys'
 import { atom } from 'jotai'
-import { defaults, uniqueId } from 'lodash-es'
+import { defaults, defaultsDeep, uniqueId } from 'lodash-es'
 import { PartialDeep, SetOptional, SetRequired } from 'type-fest'
 
 import { migrateOperation } from '../../models/converter'
 import { CopilotDocV1 } from '../../models/copilot.schema'
+import { findOperatorByName, getDefaultRequirements } from '../../models/operator'
 import { FavGroup, favGroupAtom } from '../../store/useFavGroups'
 import { FavOperator, favOperatorAtom } from '../../store/useFavOperators'
 import { snakeCaseKeysUnicode } from '../../utils/object'
@@ -51,8 +52,18 @@ export function createGroup(initialValues: Partial<Omit<EditorGroup, 'id' | 'ope
   return group
 }
 
-export function createOperator(initialValues: Omit<EditorOperator, 'id'>): EditorOperator {
-  const operator: EditorOperator = defaults({ id: uniqueId() }, initialValues)
+export function createOperator(
+  initialValues: Omit<EditorOperator, 'id'>,
+  applyDefaultRequirements = true,
+): EditorOperator {
+  const info = findOperatorByName(initialValues.name)
+  const shouldApplyDefaultRequirements = applyDefaultRequirements && (!info || info.prof !== 'TOKEN')
+  const defaultRequirements = shouldApplyDefaultRequirements ? getDefaultRequirements(info?.rarity) : undefined
+  const operator: EditorOperator = defaultsDeep(
+    { id: uniqueId() } satisfies Omit<EditorOperator, 'name'>,
+    initialValues,
+    { requirements: defaultRequirements } satisfies Omit<EditorOperator, 'id' | 'name'>,
+  )
   return operator
 }
 

--- a/src/components/editor2/reconciliation.ts
+++ b/src/components/editor2/reconciliation.ts
@@ -61,11 +61,11 @@ export function createOperator(
   let defaultRequirements: CopilotDocV1.Requirements | undefined
   if (shouldApplyDefaultRequirements) {
     const rarity = info?.rarity ?? 6
-    const customDefaults = getEditorConfig().operatorDefaults?.byRarity?.[rarity]
-    if (customDefaults) {
+    const preset = getEditorConfig().operatorPreset?.byRarity?.[rarity]
+    if (preset) {
       defaultRequirements = {
-        level: customDefaults.level,
-        elite: customDefaults.elite,
+        level: preset.level,
+        elite: preset.elite,
       }
     }
     defaultRequirements = defaults({}, defaultRequirements, getDefaultRequirements(rarity))

--- a/src/components/viewer/OperationViewer.tsx
+++ b/src/components/viewer/OperationViewer.tsx
@@ -1,4 +1,5 @@
 import {
+  AnchorButton,
   Button,
   ButtonGroup,
   Callout,
@@ -13,20 +14,19 @@ import {
   MenuDivider,
   MenuItem,
   NonIdealState,
+  PopoverNext,
   Switch,
   Tag,
-  PopoverNext,
   Tooltip,
-  AnchorButton,
 } from '@blueprintjs/core'
 import { ErrorBoundary } from '@sentry/react'
 
 import { banComments, deleteOperation, rateOperation, useOperation, useRefreshOperations } from 'apis/operation'
 import clsx from 'clsx'
 import { useAtom } from 'jotai'
-import { BanCommentsStatusEnum, CopilotSetStatus } from 'zoot-plus-client'
 import { ComponentType, FC, useEffect, useState } from 'react'
 import { copyShortCode, handleDownloadJSON } from 'services/operation'
+import { BanCommentsStatusEnum, CopilotSetStatus } from 'zoot-plus-client'
 
 import { FactItem } from 'components/FactItem'
 import { HelperText } from 'components/HelperText'
@@ -52,7 +52,6 @@ import {
   getModuleName,
   getSkillCount,
   useLocalizedOperatorName,
-  withDefaultRequirements,
 } from '../../models/operator'
 import { gridModeAtom } from '../../store/pref'
 import { formatError } from '../../utils/error'
@@ -357,12 +356,11 @@ export const OperationViewer: ComponentType<{
 
 const OperatorCard: FC<{
   operator: CopilotDocV1.Operator
-  version?: number
-}> = ({ operator, version = 1 }) => {
+}> = ({ operator }) => {
   const t = useTranslation()
   const displayName = useLocalizedOperatorName(operator.name)
   const info = OPERATORS.find((o) => o.name === operator.name)
-  const { level, elite, skillLevel, module } = withDefaultRequirements(operator.requirements, info?.rarity)
+  const { level, elite, skillLevel, module } = operator.requirements ?? {}
   const skillCount = info ? Math.max(getSkillCount(info), operator.skill ?? 1) : 3
 
   return (
@@ -376,7 +374,7 @@ const OperatorCard: FC<{
             fallback={displayName}
             sourceSize={96}
           />
-          {module !== CopilotDocV1.Module.Default && (
+          {module !== undefined && module !== CopilotDocV1.Module.Default && (
             <div
               title={t.components.viewer.OperationViewer.module_title({
                 count: module,
@@ -397,19 +395,19 @@ const OperatorCard: FC<{
           />
         )}
       </div>
-      {version >= 2 && info?.prof !== 'TOKEN' && (
-        <>
-          <div className="absolute top-1 -left-5 ml-[2px] px-3 py-4 rounded-full bg-[radial-gradient(rgba(0,0,0,0.6)_10%,rgba(0,0,0,0.08)_30%,rgba(0,0,0,0)_45%)] pointer-events-none">
+      {level !== undefined && elite !== undefined && (
+        <div className="absolute -top-2 -left-4 flex items-center flex-col-reverse">
+          <div className="-mt-5 px-3 py-4 rounded-full bg-[radial-gradient(rgba(0,0,0,0.6)_10%,rgba(0,0,0,0.08)_35%,rgba(0,0,0,0)_50%)] pointer-events-none">
             <img
-              className="w-7 h-6 object-contain"
+              className="w-7 h-6 object-contain pointer-events-auto"
               src={getEliteIconUrl(elite)}
               alt={t.models.operator.elite({ level: elite })}
             />
           </div>
-          <div className="absolute -top-2 -left-2 w-8 h-8 pr-px leading-7 rounded-full border-2 border-yellow-300 bg-black/50 text-lg text-white font-semibold text-center shadow-[0_1px_2px_rgba(0,0,0,0.9)]">
+          <div className="w-8 h-8 leading-7 rounded-full border-2 border-yellow-300 bg-black/50 text-lg text-white font-semibold text-center shadow-[0_1px_2px_rgba(0,0,0,0.9)]">
             {level}
           </div>
-        </>
+        </div>
       )}
 
       <ul className="flex flex-col gap-1 ml-1">
@@ -428,21 +426,18 @@ const OperatorCard: FC<{
               title={t.models.operator.skill_number({ count: skillNumber })}
             >
               <div className="w-6 h-6 flex items-center justify-center font-bold text-xl border-2 border-current">
-                {version >= 2 ? (
-                  selected ? (
-                    skillLevel <= 7 ? (
-                      skillLevel
-                    ) : (
-                      <MasteryIcon
-                        className="w-4 h-4"
-                        mastery={skillLevel - 7}
-                        subClassName="fill-gray-300 dark:fill-gray-500"
-                      />
-                    )
-                  ) : undefined
-                ) : (
-                  skillNumber
-                )}
+                {selected &&
+                  (skillLevel === undefined ? (
+                    <Icon icon="tick" />
+                  ) : skillLevel <= 7 ? (
+                    skillLevel
+                  ) : (
+                    <MasteryIcon
+                      className="w-4 h-4"
+                      mastery={skillLevel - 7}
+                      subClassName="fill-gray-300 dark:fill-gray-500"
+                    />
+                  ))}
               </div>
             </li>
           )
@@ -623,7 +618,7 @@ function OperationViewerInnerDetails({ operation }: { operation: Operation }) {
             />
           )}
           {operation.parsedContent.opers?.map((operator) => (
-            <OperatorCard key={operator.name} operator={operator} version={operation.parsedContent.version} />
+            <OperatorCard key={operator.name} operator={operator} />
           ))}
         </div>
         <div className="flex flex-wrap gap-4 mt-4">
@@ -632,7 +627,7 @@ function OperationViewerInnerDetails({ operation }: { operation: Operation }) {
               <H6 className="mb-3 text-gray-800">{group.name}</H6>
               <div className="flex flex-wrap px-2 gap-6">
                 {group.opers?.filter(Boolean).map((operator) => (
-                  <OperatorCard key={operator.name} operator={operator} version={operation.parsedContent.version} />
+                  <OperatorCard key={operator.name} operator={operator} />
                 ))}
 
                 {group.opers?.filter(Boolean).length === 0 && (

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -557,6 +557,14 @@
           "cn": "编辑器设置",
           "en": "Editor Settings"
         },
+        "edit": {
+          "cn": "编辑",
+          "en": "Edit"
+        },
+        "ui": {
+          "cn": "界面",
+          "en": "UI"
+        },
         "show_linker_buttons": {
           "cn": "始终显示动作之间的按钮",
           "en": "Always Show Buttons Between Actions"
@@ -568,6 +576,28 @@
         "show_errors_by_default": {
           "cn": "默认显示验证错误",
           "en": "Show Validation Errors by Default"
+        },
+        "operator_defaults": {
+          "cn": "干员默认值",
+          "en": "Operator Defaults"
+        },
+        "reset_to_default": {
+          "cn": "重置所有数据为默认值",
+          "en": "Reset all the values to default"
+        },
+        "defaults_when_adding": {
+          "cn": "添加干员时使用的默认值",
+          "en": "Default values when adding an operator"
+        },
+        "rarity": {
+          "cn": {
+            "0": "{{count}}星（通常为召唤物）",
+            "other": "{{count}}星"
+          },
+          "en":{
+            "0": "{{count}}-star (usually a summon)",
+            "other": "{{count}}-star"
+          }
         },
         "history_limit": {
           "cn": "撤销记录上限",

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -577,17 +577,17 @@
           "cn": "默认显示验证错误",
           "en": "Show Validation Errors by Default"
         },
-        "operator_defaults": {
-          "cn": "干员默认值",
-          "en": "Operator Defaults"
+        "operator_presets": {
+          "cn": "干员预设",
+          "en": "Operator Presets"
         },
         "reset_to_default": {
-          "cn": "重置所有数据为默认值",
-          "en": "Reset all the values to default"
+          "cn": "重置所有选项为默认值",
+          "en": "Reset all the options to default"
         },
-        "defaults_when_adding": {
-          "cn": "添加干员时使用的默认值",
-          "en": "Default values when adding an operator"
+        "presets_when_adding": {
+          "cn": "添加干员时使用的预设值",
+          "en": "Presets when adding an operator"
         },
         "rarity": {
           "cn": {

--- a/src/i18n/translations.json
+++ b/src/i18n/translations.json
@@ -824,6 +824,14 @@
           "cn": "精英{{level}}",
           "en": "Elite {{level}}"
         },
+        "level": {
+          "cn": "等级（可使用鼠标滚轮调整）",
+          "en": "Level (use mouse wheel to adjust)"
+        },
+        "level_unset": {
+          "cn": "未设置等级",
+          "en": "Level not set"
+        },
         "module": {
           "cn": "模组",
           "en": "Module"
@@ -839,6 +847,10 @@
             "0": "Switch to Original Module",
             "other": "Switch to {{name}} Module"
           }
+        },
+        "selected_skill": {
+          "cn": "{{skill}}（可使用鼠标滚轮调整等级）",
+          "en": "{{skill}} (use mouse wheel to adjust level)"
         },
         "skill_not_available": {
           "cn": "当前等级未解锁该技能",

--- a/src/models/operator.ts
+++ b/src/models/operator.ts
@@ -104,14 +104,6 @@ export function getDefaultRequirements(rarity = 6) {
   return defaultRequirementsByRarity[rarity] ?? defaultRequirementsByRarity[6]
 }
 
-export function withDefaultRequirements(
-  baseRequirements: CopilotDocV1.Requirements = {},
-  rarity = 6,
-): Required<CopilotDocV1.Requirements> {
-  const defaultRequirements = getDefaultRequirements(rarity)
-  return defaults({}, baseRequirements, defaultRequirements)
-}
-
 export function adjustOperatorLevel({
   // 未知稀有度按6星算
   rarity = 6,

--- a/src/models/operator.ts
+++ b/src/models/operator.ts
@@ -1,7 +1,7 @@
 import { IconName } from '@blueprintjs/core'
 
 import { useAtomValue } from 'jotai'
-import { clamp, defaults, mapValues } from 'lodash-es'
+import { clamp, mapValues } from 'lodash-es'
 
 import { CopilotDocV1 } from 'models/copilot.schema'
 


### PR DESCRIPTION
- 在编辑器 v2 中添加干员时，直接填入预设好的 requirements 而不是留空
- 允许用户自定义干员预设（编辑器设置->干员预设）：
   <img width="528" height="474" alt="image" src="https://github.com/user-attachments/assets/7939bc36-f14d-49d9-a473-62815dd115cc" />
- 在浏览页或者编辑器里显示干员时，如果 requirements 的某些字段为空，则直接显示空值而不是默认值：
   <img width="153" height="163" alt="image" src="https://github.com/user-attachments/assets/b7a12f0a-a1f3-4954-b12b-13026182b7e7" />
   <img width="410" height="166" alt="image" src="https://github.com/user-attachments/assets/b53a242f-859d-4070-b1e4-592ad931d0d0" />

## Summary by Sourcery

支持可配置的干员需求预设，并且准确保留和展示未设置的需求字段。

New Features:
- 在 Editor v2 中为新添加的干员按稀有度添加可配置的干员预设。
- 在 Editor v2 设置中添加干员预设管理功能。
- 保留未设置的干员需求，并在作战查看器和编辑器中显示为空值。

Enhancements:
- 重构干员控件为可复用的等级、技能和模组组件，同时支持部分指定的需求。

Chores:
- 扩展数值输入以支持非数值的占位符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support configurable operator requirements presets and accurately preserve and display unset requirement fields.

New Features:
- Add configurable operator presets by rarity for newly added operators in Editor v2.
- Add operator preset management to Editor v2 settings.
- Preserve unset operator requirements and display empty values in the operation viewer and editor.

Enhancements:
- Refactor operator controls into reusable level, skill, and module components while supporting partially specified requirements.

Chores:
- Extend numeric inputs to handle non-numeric placeholder values.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

支持可配置的干员需求预设，并且准确保留和展示未设置的需求字段。

New Features:
- 在 Editor v2 中为新添加的干员按稀有度添加可配置的干员预设。
- 在 Editor v2 设置中添加干员预设管理功能。
- 保留未设置的干员需求，并在作战查看器和编辑器中显示为空值。

Enhancements:
- 重构干员控件为可复用的等级、技能和模组组件，同时支持部分指定的需求。

Chores:
- 扩展数值输入以支持非数值的占位符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support configurable operator requirements presets and accurately preserve and display unset requirement fields.

New Features:
- Add configurable operator presets by rarity for newly added operators in Editor v2.
- Add operator preset management to Editor v2 settings.
- Preserve unset operator requirements and display empty values in the operation viewer and editor.

Enhancements:
- Refactor operator controls into reusable level, skill, and module components while supporting partially specified requirements.

Chores:
- Extend numeric inputs to handle non-numeric placeholder values.

</details>

</details>