### PR TITLE
chore: bump pnpm to v12

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -20,9 +20,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 11.3.0
+        uses: pnpm/setup@v2
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 11.3.0
+        uses: pnpm/setup@v2
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v6

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -33,9 +33,7 @@ jobs:
           show-progress: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 11.3.0
+        uses: pnpm/setup@v2
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v6

--- a/.github/workflows/scripts-update.yml
+++ b/.github/workflows/scripts-update.yml
@@ -22,9 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 11.3.0
+        uses: pnpm/setup@v2
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -89,5 +89,6 @@
     "tsx": "^4.23.12",
     "typescript": "7.0.2",
     "vite": "^8.2.1"
-  }
+  },
+  "packageManager": "pnpm@12.0.0-rc.7"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0-rc.7
+        version: 12.0.0-rc.7
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.7':
+    resolution: {integrity: sha512-IVRQGs1GB5YcVivwGewvdHkdCBrTYoInSnvJMslYa/BDTXDxQ352gVwpw0x7JvyfEKLrYcPQERxLBkPrjj2abA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0-rc.7':
+    resolution: {integrity: sha512-L1tyIoFaAyOFYKxIboJx3yaVhdzjW0kEtrgxqAIbYosCO97jdrd5uLDFhY7kh8UbdTNy5Je1mVj+6e7YOJmbzQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.7':
+    resolution: {integrity: sha512-nDTlQXIwySKDkM9pkUazRs08xzdhZAdhBpd5afn/v/ECvcrSMPgGqDqDOY8xxchdv0BkX+OTjyEGZI3MYbSlSg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0-rc.7':
+    resolution: {integrity: sha512-bs2dlLs+gVjs7gmM4zrhHC20ca20EAjluvkpBIoQJe+rf6gXEKtaMo7WcbnpsQChCEv3GhM//hVoRnbRZhR/jw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.7':
+    resolution: {integrity: sha512-fGdJQx0pXAbMYE36SiCHbHVvaOWyPKyBuVMlNTHU3XWfX94kiOx7pEzfAlODTYEFyk9vZABSLyyQZ2EvVSNKiA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0-rc.7':
+    resolution: {integrity: sha512-NZ16HBgXA6CPL4qCm5fku/C5paHZSLT243bG/27hCGysAXkN+ZJy+rZZKx6SKGUzVimi+9t0owPUNZ6XLSkWzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0-rc.7':
+    resolution: {integrity: sha512-JKrB3taWXcN1OtZq95X5Sfe/Dk2JYkwgd+qXNmjK/RHpiS+G1pE45L5u77KXVhQQ8MoctLthK1CMA5TbXX3bIg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0-rc.7':
+    resolution: {integrity: sha512-AVEC3/Q+opA1npNqM+yqirXvufRpftoLwWs9OlRE7Euhx76FGHGkB72fi2VyNiFBkfovcwOfwOPM0h1geVFYaw==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.0.0-rc.7:
+    resolution: {integrity: sha512-HZZwaee7QL7qTi67X01s+qsJkRlZPNK/0mUW9MbhUaOH2bOiBfjWKSZNa9dks15b/bOPqc95jmJSAzU7xvuyVA==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0-rc.7':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0-rc.7':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0-rc.7':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0-rc.7':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0-rc.7':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0-rc.7':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0-rc.7':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0-rc.7':
+    optional: true
+
+  pnpm@12.0.0-rc.7:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0-rc.7
+      '@pnpm/exe.darwin-x64': 12.0.0-rc.7
+      '@pnpm/exe.linux-arm64': 12.0.0-rc.7
+      '@pnpm/exe.linux-arm64-musl': 12.0.0-rc.7
+      '@pnpm/exe.linux-x64': 12.0.0-rc.7
+      '@pnpm/exe.linux-x64-musl': 12.0.0-rc.7
+      '@pnpm/exe.win32-arm64': 12.0.0-rc.7
+      '@pnpm/exe.win32-x64': 12.0.0-rc.7
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 allowBuilds:
   esbuild: true
-  zoot-plus-client: true
+  zoot-plus-client@git+https://github.com/ZOOT-Plus/zoot-plus-client-ts.git: true
   sharp: true
   unrs-resolver: true
 


### PR DESCRIPTION
- 指定 pnpm 版本为 12
- 更新了 `pnpm-workspace.yaml` 里 `zoot-plus-client` 的语法以修复安装报错的问题，该错误从 v11.11 开始出现，新语法从 v11.19 开始支持 （https://pnpm.io/settings/build#allowbuilds）

## Summary by Sourcery

升级项目自动化和工作区配置以兼容 pnpm 12。

Bug Fixes（错误修复）:
- 更新工作区构建审批语法，以便 pnpm 12 能够在安装基于 Git 的 `zoot-plus-client` 依赖时不再报错。

Enhancements（增强）:
- 在整个项目及其部署和 CI 工作流中采用 pnpm 12。

CI:
- 使用当前的 pnpm setup action，在 CI 和部署工作流中统一标准化 pnpm 的安装与配置。

Chores（杂务）:
- 记录 pnpm 12.0.0-rc.7 作为项目所使用的包管理器版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade the project automation and workspace configuration for pnpm 12 compatibility.

Bug Fixes:
- Update the workspace build approval syntax so pnpm 12 can install the Git-based zoot-plus-client dependency without errors.

Enhancements:
- Adopt pnpm 12 across the project and its deployment and CI workflows.

CI:
- Standardize pnpm setup across CI and deployment workflows using the current pnpm setup action.

Chores:
- Record pnpm 12.0.0-rc.7 as the project package manager version.

</details>